### PR TITLE
Include time in video titles

### DIFF
--- a/resources/lib/channels/wo/bvn.py
+++ b/resources/lib/channels/wo/bvn.py
@@ -110,11 +110,12 @@ def list_videos(plugin, item_id, day_id):
         list_video_id = video_datas.find('a').get('href').rsplit('/')
         video_id = list_video_id[len(list_video_id)-1]
         video_title = ''
+        video_time = video_datas.find('time', class_="m-section__scroll__item__bottom__time").text.replace('.', ':')
         if video_datas.find('span', class_="m-section__scroll__item__bottom__title--sub").string is not None:
-            video_title = video_datas.find('span', class_="m-section__scroll__item__bottom__title").text + \
-                ' - ' + video_datas.find('span', class_="m-section__scroll__item__bottom__title--sub").text
+            video_title = video_time + ' - ' + video_datas.find('span', class_="m-section__scroll__item__bottom__title").text + \
+                ': ' + video_datas.find('span', class_="m-section__scroll__item__bottom__title--sub").text
         else:
-            video_title = video_datas.find('span', class_="m-section__scroll__item__bottom__title").text
+            video_title = video_time + ' - ' + video_datas.find('span', class_="m-section__scroll__item__bottom__title").text
         video_image = URL_ROOT + video_datas.find('img').get('data-src')
 
         item = Listitem()


### PR DESCRIPTION
Despite it being replay, BVN compiles a list of broadcasts for each day in a specific order. Not including something like the time in the title makes it impossible to distinguish certain broadcasts because you can have multiple items with the same title (news, etc). It would result in those items being listed together as sorting is being done based on title by default, making it look like a duplicate entry bug.

Sorting in descending order would be even better, but item.info['sorttitle'] with including an index before the title does not seem to be respected.