### PR TITLE
Update mytf1.py - to show all replay

### DIFF
--- a/resources/lib/root/channels/fr/mytf1.py
+++ b/resources/lib/root/channels/fr/mytf1.py
@@ -122,7 +122,6 @@ def list_shows(params):
     else:
         url = ''.join((
             URL_ROOT,
-            params.channel_name,
             '/programmes-tv'))
         file_path = utils.download_catalog(
             url,


### PR DESCRIPTION
Sur le site https://www.tf1.fr/programmes-tv, certains replay ne sont pas classé dans les chaines (comme TF1 par exemple)

https://www.tf1.fr/programmes-tv -> liste global des replay (TF1, TMC, ...)
https://www.tf1.fr/tf1/programmes-tv -> uniquement TF1

Hors il n'est dans ce cas pas possible d'accèder a certains replay comme :
- https://www.tf1.fr/tf1/la-verite-sur-l-affaire-harry-quebert
- https://www.tf1.fr/tf1/danse-avec-les-stars

Merci d'avance.
Cordialement.