### PR TITLE
Reuse token for an hour

### DIFF
--- a/resources/lib/channels/wo/bvn.py
+++ b/resources/lib/channels/wo/bvn.py
@@ -146,7 +146,7 @@ def get_video_url(
         plugin, item_id, video_id, download_mode=False, video_label=None):
 
     # get token
-    resp = urlquick.get(URL_TOKEN, max_age = -1)
+    resp = urlquick.get(URL_TOKEN, max_age = 3600)
     token_json_parser = json.loads(resp.text)
     token = token_json_parser["token"]
 


### PR DESCRIPTION
At first I did not want to bother checking how long a token is really valid, so I forced it to not being cached at all.
Out of interest, however, and with using this add-on in practice, every call less is already a speed gain.

Tokens are valid for an hour. The timer appears to be reset after each subsequent use (URL_VIDEO_REPLAY), but just keeping it for an hour in total is already better than nothing.