### PR TITLE
Fix handling of null video title for francetv

### DIFF
--- a/resources/lib/channels/fr/francetv.py
+++ b/resources/lib/channels/fr/francetv.py
@@ -408,7 +408,8 @@ def populate_item(item, video, include_program_name=False, **kwargs):
     if video['type'] == "extrait":
         item.label += "[extrait] "
 
-    item.label += video['title']
+    if "title" in video and video['title']:
+        item.label += video['title']
 
     # It's too bad item.info['title'] overrules item.label everywhere
     # so there's no difference between what is shown in the video list


### PR DESCRIPTION
Some videos may have a null title resulting in the following error:

```
FATAL: [Catch-up-TV-&-More.support] coercing to Unicode: need string or buffer, NoneType found
  Traceback (most recent call last):
    File "/home/pi/.kodi/addons/script.module.codequick/lib/codequick/support.py", line 295, in run_callback
      redirect = parent_ins._process_results(results)
    File "/home/pi/.kodi/addons/script.module.codequick/lib/codequick/route.py", line 95, in _process_results
      raw_listitems = validate_listitems(raw_listitems)
    File "/home/pi/.kodi/addons/script.module.codequick/lib/codequick/route.py", line 34, in validate_listitems
      raw_listitems = list(raw_listitems)
    File "/home/pi/.kodi/addons/plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv.py", line 217, in list_videos
      broadcast_id = populate_item(item, video)
    File "/home/pi/.kodi/addons/plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv.py", line 411, in populate_item
      item.label += video['title']
  TypeError: coercing to Unicode: need string or buffer, NoneType found
```

This happens now for example with this URL: `http://api-front.yatta.francetv.fr/standard/publish/taxonomies/france-2_fort-boyard/contents/?filter=with-no-vod%2Conly-visible&sort=sort+%3D+begin_date%3Adesc&page=1&size=20`