### PR TITLE
add a missing item_post_treatment for allvid item

### DIFF
--- a/resources/lib/channels/fr/6play.py
+++ b/resources/lib/channels/fr/6play.py
@@ -211,6 +211,7 @@ def list_program_categories(plugin, item_id, program_id, **kwargs):
                       item_id=item_id,
                       program_id=program_id,
                       sub_category_id=None)
+    item_post_treatment(item)
     yield item
 
 


### PR DESCRIPTION
now we can for sample "add m6\capital\all vid" to addon favourites.