### PR TITLE
Add X-Forwarded-For setting

### DIFF
--- a/resources/lib/resolver_proxy.py
+++ b/resources/lib/resolver_proxy.py
@@ -185,7 +185,9 @@ def get_brightcove_video_json(plugin,
             web_utils.get_random_ua,
             'Accept':
             'application/json;pk=%s' %
-            (get_brightcove_policy_key(data_account, data_player))
+            (get_brightcove_policy_key(data_account, data_player)),
+            'X-Forwarded-For':
+            plugin.setting.get_string('header_x-forwarded-for')
         })
     json_parser = json.loads(resp.text)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1333,6 +1333,7 @@
         <setting label="30370" type="action" action="RunPlugin(plugin://plugin.video.catchuptvandmore/main/clear_cache/)"/>
         <setting label="" type="bool" id="show_hidden_items_information" default="true" visible="false"/>
         <setting label="" type="bool" id="show_live_tv_m3u_info" default="true" visible="false"/>
+        <setting label="X-Forwarded-For" type="text" id="header_x-forwarded-for" default=""/>
     </category>
     <!-- Advanced settings / Tools and other things to save -->
 


### PR DESCRIPTION
This adds support for specifying an `X-Forwarded-For` header when making requests which can be used to bypass geo restriction on some video providers.

This was tested on Brightcove with the tver.jp channel ([sample episode](https://tver.jp/corner/f0041182)).