### PR TITLE
Fix missing parentheses on get_random_ua calls

### DIFF
--- a/resources/lib/channels/be/rtlplaybe.py
+++ b/resources/lib/channels/be/rtlplaybe.py
@@ -123,7 +123,7 @@ def list_categories(plugin, item_id, **kwargs):
     """
     resp = urlquick.get(URL_ROOT % ('rtlbe_' + item_id),
                         headers={
-                            'User-Agent': web_utils.get_random_ua,
+                            'User-Agent': web_utils.get_random_ua(),
                             'x-customer-name': 'rtlbe'})
     json_parser = json.loads(resp.text)
 
@@ -149,7 +149,7 @@ def list_programs(plugin, item_id, category_id, **kwargs):
     """
     resp = urlquick.get(URL_CATEGORY % category_id,
                         headers={
-                            'User-Agent': web_utils.get_random_ua,
+                            'User-Agent': web_utils.get_random_ua(),
                             'x-customer-name': 'rtlbe'
                         })
     json_parser = json.loads(resp.text)
@@ -192,7 +192,7 @@ def list_program_categories(plugin, item_id, program_id, **kwargs):
     """
     resp = urlquick.get(URL_SUBCATEGORY % program_id,
                         headers={
-                            'User-Agent': web_utils.get_random_ua,
+                            'User-Agent': web_utils.get_random_ua(),
                             'x-customer-name': 'rtlbe'
                         })
     json_parser = json.loads(resp.text)
@@ -229,7 +229,7 @@ def list_videos(plugin, item_id, program_id, sub_category_id, **kwargs):
         url = URL_VIDEOS % (program_id, sub_category_id)
     resp = urlquick.get(url,
                         headers={
-                            'User-Agent': web_utils.get_random_ua,
+                            'User-Agent': web_utils.get_random_ua(),
                             'x-customer-name': 'rtlbe'
                         })
     json_parser = json.loads(resp.text)
@@ -312,7 +312,7 @@ def get_video_url(plugin,
     if cqu.get_kodi_version() < 18:
         video_json = urlquick.get(URL_JSON_VIDEO % video_id,
                                   headers={
-                                      'User-Agent': web_utils.get_random_ua,
+                                      'User-Agent': web_utils.get_random_ua(),
                                       'x-customer-name': 'rtlbe'
                                   },
                                   max_age=-1)
@@ -333,7 +333,7 @@ def get_video_url(plugin,
             elif 'h264' in asset["type"]:
                 manifest = urlquick.get(
                     asset['full_physical_path'],
-                    headers={'User-Agent': web_utils.get_random_ua},
+                    headers={'User-Agent': web_utils.get_random_ua()},
                     max_age=-1)
                 if 'drm' not in manifest.text:
                     all_datas_videos_quality.append(asset["video_quality"])
@@ -370,7 +370,7 @@ def get_video_url(plugin,
     else:
         video_json = urlquick.get(URL_JSON_VIDEO % video_id,
                                   headers={
-                                      'User-Agent': web_utils.get_random_ua,
+                                      'User-Agent': web_utils.get_random_ua(),
                                       'x-customer-name': 'rtlbe'
                                   },
                                   max_age=-1)
@@ -410,7 +410,7 @@ def get_video_url(plugin,
         resp2 = urlquick.post(URL_COMPTE_LOGIN,
                               data=payload,
                               headers={
-                                  'User-Agent': web_utils.get_random_ua,
+                                  'User-Agent': web_utils.get_random_ua(),
                                   'referer': 'https://www.rtlplay.be/connexion'
                               })
         json_parser = json.loads(
@@ -431,7 +431,7 @@ def get_video_url(plugin,
             'x-auth-gigya-signature': account_signature,
             'x-auth-gigya-signature-timestamp': account_timestamp,
             'x-auth-gigya-uid': account_id,
-            'User-Agent': web_utils.get_random_ua,
+            'User-Agent': web_utils.get_random_ua(),
             'x-customer-name': 'rtlbe'
         }
         token_json = urlquick.get(URL_TOKEN_DRM % (account_id, video_id),
@@ -516,7 +516,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
     resp2 = urlquick.post(URL_COMPTE_LOGIN,
                           data=payload,
                           headers={
-                              'User-Agent': web_utils.get_random_ua,
+                              'User-Agent': web_utils.get_random_ua(),
                               'referer': 'https://www.rtlplay.be/connexion'
                           })
     json_parser = json.loads(
@@ -538,7 +538,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         'x-auth-gigya-signature': account_signature,
         'x-auth-gigya-signature-timestamp': account_timestamp,
         'x-auth-gigya-uid': account_id,
-        'User-Agent': web_utils.get_random_ua,
+        'User-Agent': web_utils.get_random_ua(),
         'x-customer-name': 'rtlbe'
     }
     channel = 'rtlbe_' + item_id
@@ -551,7 +551,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     video_json = urlquick.get(URL_LIVE_JSON % (channel),
                               headers={
-                                  'User-Agent': web_utils.get_random_ua,
+                                  'User-Agent': web_utils.get_random_ua(),
                                   'x-customer-name': 'rtlbe'},
                               max_age=-1)
     json_parser = json.loads(video_json.text)

--- a/resources/lib/channels/ca/noovo.py
+++ b/resources/lib/channels/ca/noovo.py
@@ -154,7 +154,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(
-        video_url, headers={'User-Agent': web_utils.get_random_ua}, max_age=-1)
+        video_url, headers={'User-Agent': web_utils.get_random_ua()}, max_age=-1)
     data_account = re.compile(r'data-account\=\"(.*?)\"').findall(resp.text)[0]
     data_player = re.compile(r'data-player\=\"(.*?)\"').findall(resp.text)[0]
     data_video_id = re.compile(r'data-video-id\=\"(.*?)\"').findall(

--- a/resources/lib/channels/ca/telemag.py
+++ b/resources/lib/channels/ca/telemag.py
@@ -108,7 +108,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     root = resp.parse()
     stream_url = root.find(".//iframe[@id='main_video']").get('src')

--- a/resources/lib/channels/ch/becurioustv.py
+++ b/resources/lib/channels/ch/becurioustv.py
@@ -61,7 +61,7 @@ def list_categories(plugin, item_id, **kwargs):
     - ...
     """
     resp = urlquick.get(URL_ROOT,
-                        headers={'User-Agent': web_utils.get_random_ua})
+                        headers={'User-Agent': web_utils.get_random_ua()})
     root = resp.parse("ul", attrs={"class": "sub-menu"})
 
     for category_datas in root.iterfind(".//li"):

--- a/resources/lib/channels/ch/tvm3.py
+++ b/resources/lib/channels/ch/tvm3.py
@@ -147,13 +147,13 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     player_id = re.compile(r'\;player\=(.*?)\'').findall(resp.text)[0]
     session_urlquick = urlquick.Session(allow_redirects=False)
     resp2 = session_urlquick.get(
         URL_STREAM % player_id,
-        headers={'User-Agent': web_utils.get_random_ua},
+        headers={'User-Agent': web_utils.get_random_ua()},
         max_age=-1)
     location_url = resp2.headers['Location']
     resp3 = urlquick.get(location_url.replace(

--- a/resources/lib/channels/es/atresplayer.py
+++ b/resources/lib/channels/es/atresplayer.py
@@ -258,13 +258,13 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     lives_json = re.compile(r'window.__ENV__ = (.*?)\;').findall(resp.text)[0]
     json_parser = json.loads(lives_json)
     live_stream_json = urlquick.get(
         URL_LIVE_STREAM % json_parser[LIVE_ATRES_PLAYER[item_id]],
-        headers={'User-Agent': web_utils.get_random_ua},
+        headers={'User-Agent': web_utils.get_random_ua()},
         max_age=-1)
     live_stream_jsonparser = json.loads(live_stream_json.text)
     if "sources" in live_stream_jsonparser:

--- a/resources/lib/channels/es/realmadridtv.py
+++ b/resources/lib/channels/es/realmadridtv.py
@@ -63,7 +63,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         final_language = item_dict['language']
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     url_lives = re.compile(r'data-stream-hsl-url=\'(.*?)\'').findall(resp.text)
 

--- a/resources/lib/channels/fr/6play.py
+++ b/resources/lib/channels/fr/6play.py
@@ -302,7 +302,7 @@ def get_video_url(plugin,
     if cqu.get_kodi_version() < 18:
         video_json = urlquick.get(URL_JSON_VIDEO % video_id,
                                   headers={
-                                      'User-Agent': web_utils.get_random_ua,
+                                      'User-Agent': web_utils.get_random_ua(),
                                       'x-customer-name': 'm6web'
                                   },
                                   max_age=-1)
@@ -324,7 +324,7 @@ def get_video_url(plugin,
             elif 'h264' in asset["type"]:
                 manifest = urlquick.get(
                     asset['full_physical_path'],
-                    headers={'User-Agent': web_utils.get_random_ua},
+                    headers={'User-Agent': web_utils.get_random_ua()},
                     max_age=-1)
                 if 'drm' not in manifest.text:
                     all_datas_videos_quality.append(asset["video_quality"])
@@ -387,7 +387,7 @@ def get_video_url(plugin,
         resp2 = urlquick.post(URL_COMPTE_LOGIN,
                               data=payload,
                               headers={
-                                  'User-Agent': web_utils.get_random_ua,
+                                  'User-Agent': web_utils.get_random_ua(),
                                   'referer': 'https://www.6play.fr/connexion'
                               })
         json_parser = json.loads(
@@ -421,7 +421,7 @@ def get_video_url(plugin,
 
         video_json = urlquick.get(URL_JSON_VIDEO % video_id,
                                   headers={
-                                      'User-Agent': web_utils.get_random_ua,
+                                      'User-Agent': web_utils.get_random_ua(),
                                       'x-customer-name': 'm6web'
                                   },
                                   max_age=-1)
@@ -482,14 +482,14 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         if item_id == 'mb':
             video_json = urlquick.get(
                 URL_LIVE_JSON % (item_id.upper()),
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
             json_parser = json.loads(video_json.text)
             video_assets = json_parser[item_id.upper()][0]['live']['assets']
         else:
             video_json = urlquick.get(
                 URL_LIVE_JSON % (item_id),
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
             json_parser = json.loads(video_json.text)
             video_assets = json_parser[item_id][0]['live']['assets']
@@ -553,7 +553,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         resp2 = urlquick.post(URL_COMPTE_LOGIN,
                               data=payload,
                               headers={
-                                  'User-Agent': web_utils.get_random_ua,
+                                  'User-Agent': web_utils.get_random_ua(),
                                   'referer': 'https://www.6play.fr/connexion'
                               })
         json_parser = json.loads(
@@ -594,14 +594,14 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         if item_id == '6ter':
             video_json = urlquick.get(
                 URL_LIVE_JSON % '6T',
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
             json_parser = json.loads(video_json.text)
             video_assets = json_parser['6T'][0]['live']['assets']
         else:
             video_json = urlquick.get(
                 URL_LIVE_JSON % (item_id.upper()),
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
             json_parser = json.loads(video_json.text)
             video_assets = json_parser[item_id.upper()][0]['live']['assets']

--- a/resources/lib/channels/fr/alsace20.py
+++ b/resources/lib/channels/fr/alsace20.py
@@ -175,14 +175,14 @@ def get_video_url(plugin,
         return False
 
     resp = urlquick.get(
-        video_url, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        video_url, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     root = resp.parse()
     url_stream_datas = URL_ROOT + root.find(".//div[@class='HDR_VISIO']").get(
         "data-url") + "&mode=html"
 
     resp2 = urlquick.get(
         url_stream_datas,
-        headers={"User-Agent": web_utils.get_random_ua},
+        headers={"User-Agent": web_utils.get_random_ua()},
         max_age=-1)
     json_parser = json.loads(resp2.text)
 
@@ -211,14 +211,14 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         return False
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     root = resp.parse()
     url_live_datas = URL_ROOT + root.find(".//div[@class='HDR_VISIO']").get(
         "data-url") + "&mode=html"
 
     resp2 = urlquick.get(
         url_live_datas,
-        headers={"User-Agent": web_utils.get_random_ua},
+        headers={"User-Agent": web_utils.get_random_ua()},
         max_age=-1)
     json_parser = json.loads(resp2.text)
 

--- a/resources/lib/channels/fr/antennereunion.py
+++ b/resources/lib/channels/fr/antennereunion.py
@@ -139,7 +139,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     live_html = urlquick.get(URL_LIVE,
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
     list_url_stream = re.compile(r'file"\: "(.*?)"').findall(live_html.text)
     url_live = ''

--- a/resources/lib/channels/fr/azurtv.py
+++ b/resources/lib/channels/fr/azurtv.py
@@ -52,10 +52,10 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     if 'provenceazur' in item_id:
         resp = urlquick.get(
-            URL_LIVE % 'provenceazur', headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+            URL_LIVE % 'provenceazur', headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     else:
         resp = urlquick.get(
-            URL_LIVE % 'azur', headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+            URL_LIVE % 'azur', headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/bfmlyon.py
+++ b/resources/lib/channels/fr/bfmlyon.py
@@ -72,7 +72,7 @@ def list_categories(plugin, item_id, **kwargs):
 def list_videos(plugin, item_id, page, **kwargs):
 
     resp = urlquick.get(URL_REPLAY_BFM_LYON % page,
-                        headers={'User-Agent': web_utils.get_random_ua})
+                        headers={'User-Agent': web_utils.get_random_ua()})
     root = resp.parse()
 
     for video_datas in root.iterfind(
@@ -128,7 +128,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_BFM_LYON,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
 
     root = resp.parse()

--- a/resources/lib/channels/fr/bfmparis.py
+++ b/resources/lib/channels/fr/bfmparis.py
@@ -70,7 +70,7 @@ def list_categories(plugin, item_id, **kwargs):
 def list_videos(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_REPLAY_BFMPARIS,
-                        headers={'User-Agent': web_utils.get_random_ua})
+                        headers={'User-Agent': web_utils.get_random_ua()})
     root = resp.parse()
 
     for video_datas in root.iterfind(
@@ -122,7 +122,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_BFM_PARIS,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
 
     root = resp.parse()

--- a/resources/lib/channels/fr/bfmtv.py
+++ b/resources/lib/channels/fr/bfmtv.py
@@ -216,11 +216,11 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     if item_id == 'bfmtv':
         resp = urlquick.get(URL_LIVE_BFMTV,
-                            headers={'User-Agent': web_utils.get_random_ua},
+                            headers={'User-Agent': web_utils.get_random_ua()},
                             max_age=-1)
     elif item_id == 'bfmbusiness':
         resp = urlquick.get(URL_LIVE_BFMBUSINESS,
-                            headers={'User-Agent': web_utils.get_random_ua},
+                            headers={'User-Agent': web_utils.get_random_ua()},
                             max_age=-1)
 
     root = resp.parse()

--- a/resources/lib/channels/fr/biptv.py
+++ b/resources/lib/channels/fr/biptv.py
@@ -50,5 +50,5 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     return re.compile(r'source src=\"(.*?)\"').findall(resp.text)[0]

--- a/resources/lib/channels/fr/canal10.py
+++ b/resources/lib/channels/fr/canal10.py
@@ -52,11 +52,11 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     player_id = re.compile(r'\&player\=(.*?)\"').findall(resp.text)[0]
     resp2 = urlquick.get(URL_STREAM % player_id,
-                         headers={'User-Agent': web_utils.get_random_ua},
+                         headers={'User-Agent': web_utils.get_random_ua()},
                          max_age=-1)
     json_parser = json.loads(resp2.text)
     return 'https://' + json_parser["sPlaylist"]

--- a/resources/lib/channels/fr/cnews.py
+++ b/resources/lib/channels/fr/cnews.py
@@ -133,7 +133,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(
         resp.text)[0]
@@ -149,7 +149,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_CNEWS,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]',
                          re.DOTALL).findall(resp.text)[0]

--- a/resources/lib/channels/fr/dicitv.py
+++ b/resources/lib/channels/fr/dicitv.py
@@ -55,12 +55,12 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     channel_id = re.compile(r'\?channel\=(.*?)\&').findall(resp.text)[0]
     resp2 = urlquick.get(
         URL_STREAM % channel_id,
-        headers={'User-Agent': web_utils.get_random_ua},
+        headers={'User-Agent': web_utils.get_random_ua()},
         max_age=-1)
     json_parser = json.loads(resp2.text)
     stream_url = ''

--- a/resources/lib/channels/fr/france3regions.py
+++ b/resources/lib/channels/fr/france3regions.py
@@ -207,7 +207,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         final_region = item_dict['language']
 
     resp = urlquick.get(URL_LIVES_JSON,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     json_parser = json.loads(resp.text)
 

--- a/resources/lib/channels/fr/franceinfo.py
+++ b/resources/lib/channels/fr/franceinfo.py
@@ -267,7 +267,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_JSON,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     json_parser = json.loads(resp.text)
 

--- a/resources/lib/channels/fr/gong.py
+++ b/resources/lib/channels/fr/gong.py
@@ -104,7 +104,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(r'videoId: \'(.*?)\'').findall(resp.text)[0]
     return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode,
@@ -119,6 +119,6 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     return re.compile(r'x-mpegurl" src="(.*?)"').findall(resp.text)[0]

--- a/resources/lib/channels/fr/grandlilletv.py
+++ b/resources/lib/channels/fr/grandlilletv.py
@@ -50,5 +50,5 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     return re.compile(r'file\: \"(.*?)\"').findall(resp.text)[0]

--- a/resources/lib/channels/fr/grandlitorraltv.py
+++ b/resources/lib/channels/fr/grandlitorraltv.py
@@ -50,5 +50,5 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     return re.compile(r'file\: \"(.*?)\"').findall(resp.text)[0]

--- a/resources/lib/channels/fr/gulli.py
+++ b/resources/lib/channels/fr/gulli.py
@@ -122,7 +122,7 @@ def list_programs(plugin, item_id, program_url, **kwargs):
     - ...
     """
     resp = urlquick.get(program_url,
-                        headers={'User-Agent': web_utils.get_random_ua})
+                        headers={'User-Agent': web_utils.get_random_ua()})
     json_parser = json.loads(resp.text)
 
     for program in json_parser['res']:
@@ -143,7 +143,7 @@ def list_programs(plugin, item_id, program_url, **kwargs):
 def list_videos(plugin, item_id, program_id, **kwargs):
 
     resp = urlquick.get(URL_LIST_SHOW % (get_api_key(), program_id),
-                        headers={'User-Agent': web_utils.get_random_ua})
+                        headers={'User-Agent': web_utils.get_random_ua()})
     json_parser = json.loads(resp.text)
 
     for show in json_parser['res']:
@@ -198,7 +198,7 @@ def get_video_url(plugin,
                   **kwargs):
     url_root = video_url.replace('playlist.m3u8', '')
     m3u8_content = urlquick.get(
-        video_url, headers={'User-Agent': web_utils.get_random_ua}, max_age=-1)
+        video_url, headers={'User-Agent': web_utils.get_random_ua()}, max_age=-1)
     last_url = ''
 
     for line in m3u8_content.text.splitlines():
@@ -219,13 +219,13 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     url_live = ''
     live_html = urlquick.get(URL_LIVE_TV,
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
     url_live_embeded = re.compile('<iframe src=\"(.*?)\"').findall(
         live_html.text)[0]
     root_live_embeded_html = urlquick.get(
         url_live_embeded,
-        headers={'User-Agent': web_utils.get_random_ua},
+        headers={'User-Agent': web_utils.get_random_ua()},
         max_age=-1)
     all_url_video = re.compile(r'file: \'(.*?)\'').findall(
         root_live_embeded_html.text)

--- a/resources/lib/channels/fr/kto.py
+++ b/resources/lib/channels/fr/kto.py
@@ -157,7 +157,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(r'www.youtube.com/embed/(.*?)[\?\"]').findall(
         resp.text)[0]
@@ -174,7 +174,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     list_url_stream = re.compile(r'videoUrl = \'(.*?)\'').findall(resp.text)
     url_live = ''

--- a/resources/lib/channels/fr/la_1ere.py
+++ b/resources/lib/channels/fr/la_1ere.py
@@ -191,7 +191,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         final_region = item_dict['language']
 
     resp = urlquick.get(URL_LIVES_JSON,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     json_parser = json.loads(resp.text)
 

--- a/resources/lib/channels/fr/lachainenormande.py
+++ b/resources/lib/channels/fr/lachainenormande.py
@@ -54,14 +54,14 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         return False
 
     resp = urlquick.get(
-        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     root = resp.parse()
     url_live_datas = URL_ROOT + root.find(".//div[@class='HDR_VISIO']").get(
         "data-url") + "&mode=html"
 
     resp2 = urlquick.get(
         url_live_datas,
-        headers={"User-Agent": web_utils.get_random_ua},
+        headers={"User-Agent": web_utils.get_random_ua()},
         max_age=-1)
     json_parser = json.loads(resp2.text)
 

--- a/resources/lib/channels/fr/lci.py
+++ b/resources/lib/channels/fr/lci.py
@@ -178,14 +178,14 @@ def get_video_url(plugin,
 
     url_json = URL_VIDEO_STREAM % video_id
     htlm_json = urlquick.get(url_json,
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
     json_parser = json.loads(htlm_json.text)
 
     # Check DRM in the m3u8 file
     manifest = urlquick.get(json_parser["hls"],
                             headers={
-                                'User-Agent': web_utils.get_random_ua},
+                                'User-Agent': web_utils.get_random_ua()},
                             max_age=-1).text
     if 'drm' in manifest:
         Script.notify("TEST", plugin.localize(LABELS['drm_notification']),
@@ -195,7 +195,7 @@ def get_video_url(plugin,
     root = os.path.dirname(json_parser["hls"])
 
     manifest = urlquick.get(json_parser["hls"].split('&max_bitrate=')[0],
-                            headers={'User-Agent': web_utils.get_random_ua},
+                            headers={'User-Agent': web_utils.get_random_ua()},
                             max_age=-1)
 
     final_video_url = ''
@@ -237,7 +237,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
     video_format = 'hls'
     url_json = URL_VIDEO_STREAM_2 % (video_id, video_format)
     htlm_json = urlquick.get(url_json,
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
     json_parser = json.loads(htlm_json.text)
 

--- a/resources/lib/channels/fr/lcp.py
+++ b/resources/lib/channels/fr/lcp.py
@@ -298,7 +298,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
 
     if 'dailymotion' in resp.text:
@@ -314,7 +314,7 @@ def get_video_url(plugin,
             resp.text)[0]
 
         resp2 = urlquick.get(URL_VIDEO_REPLAY % (videoId, accountId),
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
         json_parser = json.loads(
             re.compile(r'\((.*?)\);').findall(resp2.text)[0])
@@ -337,7 +337,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_SITE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(
         r'www.dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]

--- a/resources/lib/channels/fr/lequipe.py
+++ b/resources/lib/channels/fr/lequipe.py
@@ -129,12 +129,12 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     js_live_id = re.compile(r'\/js\/app\.(.*?)\.',
                             re.DOTALL).findall(resp.text)[0]
     resp2 = urlquick.get(URL_INFO_STREAM_LIVE % js_live_id,
-                         headers={'User-Agent': web_utils.get_random_ua},
+                         headers={'User-Agent': web_utils.get_random_ua()},
                          max_age=-1)
     live_id = re.compile(r'channelLiveDmId\:\"(.*?)\"',
                          re.DOTALL).findall(resp2.text)[0]

--- a/resources/lib/channels/fr/mycanal.py
+++ b/resources/lib/channels/fr/mycanal.py
@@ -457,7 +457,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(
-        next_url, headers={'User-Agent': web_utils.get_random_ua}, max_age=-1)
+        next_url, headers={'User-Agent': web_utils.get_random_ua()}, max_age=-1)
     json_parser = json.loads(resp.text)
 
     if json_parser["detail"]["informations"]['consumptionPlatform'] == 'HAPI':

--- a/resources/lib/channels/fr/mytf1.py
+++ b/resources/lib/channels/fr/mytf1.py
@@ -93,7 +93,7 @@ def list_categories(plugin, item_id, **kwargs):
     headers = {
         'content-type': 'application/json',
         'referer': 'https://www.tf1.fr/programmes-tv',
-        'User-Agent': web_utils.get_random_ua
+        'User-Agent': web_utils.get_random_ua()
     }
     resp = urlquick.get(URL_API, params=params, headers=headers)
     json_parser = json.loads(resp.text)
@@ -128,7 +128,7 @@ def list_programs(plugin, item_id, category_id, **kwargs):
     headers = {
         'content-type': 'application/json',
         'referer': 'https://www.tf1.fr/programmes-tv',
-        'User-Agent': web_utils.get_random_ua
+        'User-Agent': web_utils.get_random_ua()
     }
     resp = urlquick.get(URL_API, params=params, headers=headers)
     json_parser = json.loads(resp.text)
@@ -186,7 +186,7 @@ def list_videos(plugin, item_id, program_slug, video_type_value, offset, **kwarg
     headers = {
         'content-type': 'application/json',
         'referer': 'https://www.tf1.fr/programmes-tv',
-        'User-Agent': web_utils.get_random_ua
+        'User-Agent': web_utils.get_random_ua()
     }
     resp = urlquick.get(URL_API, params=params, headers=headers)
     json_parser = json.loads(resp.text)
@@ -232,7 +232,7 @@ def get_video_url(plugin,
     video_format = 'hls'
     url_json = URL_VIDEO_STREAM % (video_id, video_format)
     htlm_json = urlquick.get(url_json,
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
     json_parser = json.loads(htlm_json.text)
 
@@ -243,7 +243,7 @@ def get_video_url(plugin,
     # Check DRM in the m3u8 file
     manifest = urlquick.get(json_parser["url"],
                             headers={
-                                'User-Agent': web_utils.get_random_ua},
+                                'User-Agent': web_utils.get_random_ua()},
                             max_age=-1).text
     if 'drm' in manifest:
 
@@ -266,7 +266,7 @@ def get_video_url(plugin,
             url_without_max_bitrate = url_without_max_bitrate_list[0]
         manifest = urlquick.get(
             url_without_max_bitrate,
-            headers={'User-Agent': web_utils.get_random_ua},
+            headers={'User-Agent': web_utils.get_random_ua()},
             max_age=-1)
 
         lines = manifest.text.splitlines()
@@ -307,7 +307,7 @@ def get_video_url(plugin,
         url_json = URL_VIDEO_STREAM % (video_id, video_format)
         htlm_json = urlquick.get(
             url_json,
-            headers={'User-Agent': web_utils.get_random_ua},
+            headers={'User-Agent': web_utils.get_random_ua()},
             max_age=-1)
         json_parser = json.loads(htlm_json.text)
 
@@ -341,7 +341,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
     video_format = 'hls'
     url_json = URL_VIDEO_STREAM % (video_id, video_format)
     htlm_json = urlquick.get(url_json,
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
     json_parser = json.loads(htlm_json.text)
 

--- a/resources/lib/channels/fr/ouatchtv.py
+++ b/resources/lib/channels/fr/ouatchtv.py
@@ -110,7 +110,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(r'video: "(.*?)"').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin, video_id,

--- a/resources/lib/channels/fr/publicsenat.py
+++ b/resources/lib/channels/fr/publicsenat.py
@@ -137,7 +137,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(
         r'www.dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]
@@ -153,7 +153,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_SITE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(
         r'www.dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]

--- a/resources/lib/channels/fr/rmcdecouverte.py
+++ b/resources/lib/channels/fr/rmcdecouverte.py
@@ -118,7 +118,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     root = resp.parse()
     video_datas = root.find(".//div[@class='next-player player_2t_e9']")
@@ -140,7 +140,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_RMCDECOUVERTE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
 
     root = resp.parse()

--- a/resources/lib/channels/fr/rmcstory.py
+++ b/resources/lib/channels/fr/rmcstory.py
@@ -177,7 +177,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_INFO_LIVE_JSON,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     json_parser = json.loads(resp.text)
     video_id = json_parser["video"]

--- a/resources/lib/channels/fr/sportenfrance.py
+++ b/resources/lib/channels/fr/sportenfrance.py
@@ -49,7 +49,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/telegrenoble.py
+++ b/resources/lib/channels/fr/telegrenoble.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/telenantes.py
+++ b/resources/lib/channels/fr/telenantes.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'\&video_id\=(.*?)\"').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/tf1thematiques.py
+++ b/resources/lib/channels/fr/tf1thematiques.py
@@ -124,25 +124,25 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(r'www.wat.tv/embedframe/(.*?)[\"\?]').findall(
         resp.text)[0]
     url_wat_embed = URL_WAT_BY_ID % video_id
     wat_embed_html = urlquick.get(
         url_wat_embed,
-        headers={'User-Agent': web_utils.get_random_ua},
+        headers={'User-Agent': web_utils.get_random_ua()},
         max_age=-1)
     stream_id = re.compile('UVID=(.*?)&').findall(wat_embed_html.text)[0]
     url_json = URL_VIDEO_STREAM % stream_id
     htlm_json = urlquick.get(url_json,
-                             headers={'User-Agent': web_utils.get_random_ua},
+                             headers={'User-Agent': web_utils.get_random_ua()},
                              max_age=-1)
     json_parser = json.loads(htlm_json.text)
 
     # Check DRM in the m3u8 file
     manifest = urlquick.get(json_parser["hls"],
-                            headers={'User-Agent': web_utils.get_random_ua},
+                            headers={'User-Agent': web_utils.get_random_ua()},
                             max_age=-1)
     if 'drm' in manifest:
         Script.notify("TEST", plugin.localize(LABELS['drm_notification']),
@@ -152,7 +152,7 @@ def get_video_url(plugin,
     root = os.path.dirname(json_parser["hls"])
 
     manifest = urlquick.get(json_parser["hls"].split('&max_bitrate=')[0],
-                            headers={'User-Agent': web_utils.get_random_ua},
+                            headers={'User-Agent': web_utils.get_random_ua()},
                             max_age=-1)
 
     lines = manifest.text.splitlines()

--- a/resources/lib/channels/fr/tl7.py
+++ b/resources/lib/channels/fr/tl7.py
@@ -131,7 +131,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     live_id = re.compile(r'video\: \'(.*?)\'').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin, live_id, False)

--- a/resources/lib/channels/fr/tlc.py
+++ b/resources/lib/channels/fr/tlc.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/tv7bordeaux.py
+++ b/resources/lib/channels/fr/tv7bordeaux.py
@@ -49,7 +49,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'videoId \= \"(.*?)\"').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/tvr.py
+++ b/resources/lib/channels/fr/tvr.py
@@ -50,5 +50,5 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     return re.compile(r'base_m3u8_url \= \"(.*?)\"').findall(resp.text)[0]

--- a/resources/lib/channels/fr/tvt.py
+++ b/resources/lib/channels/fr/tvt.py
@@ -49,7 +49,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_ROOT, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'data-video\=\"(.*?)\"').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/tvvendee.py
+++ b/resources/lib/channels/fr/tvvendee.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/fr/via.py
+++ b/resources/lib/channels/fr/via.py
@@ -144,14 +144,14 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
         live_html = urlquick.get(
             URL_LIVE_VIAVOSGES,
-            headers={'User-Agent': web_utils.get_random_ua},
+            headers={'User-Agent': web_utils.get_random_ua()},
             max_age=-1)
         root = live_html.parse()
         url_live_datas = URL_ROOT_VIAVOSGES + root.find(
             ".//div[@class='HDR_VISIO']").get('data-url') + '&mode=html'
 
         resp = urlquick.get(url_live_datas,
-                            headers={'User-Agent': web_utils.get_random_ua},
+                            headers={'User-Agent': web_utils.get_random_ua()},
                             max_age=-1)
         json_parser = json.loads(resp.text)
 
@@ -177,12 +177,12 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         if item_id == 'viamirabelle':
             live_html = urlquick.get(
                 URL_LIVE_VIAMIRABELLE % item_id,
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
         else:
             live_html = urlquick.get(
                 URL_LIVE % item_id,
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
         root = live_html.parse()
         list_lives_datas = root.findall('.//iframe')
@@ -200,14 +200,14 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
             player_id = src_datas.split('player=')[1]
             resp2 = urlquick.get(
                 URL_STREAM_INFOMANIAK % player_id,
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
             json_parser = json.loads(resp2.text)
             return 'https://' + json_parser["sPlaylist"]
         elif 'creacast' in src_datas:
             resp2 = urlquick.get(
                 src_datas,
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
             return re.compile(r'file\: \"(.*?)\"').findall(resp2.text)[0]
         else:
@@ -218,7 +218,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
                     'action': 'video_info',
                     'refvideo': live_id
                 },
-                headers={'User-Agent': web_utils.get_random_ua},
+                headers={'User-Agent': web_utils.get_random_ua()},
                 max_age=-1)
             stream_jsonparser = json.loads(stream_json.text)
             return stream_jsonparser["data"]["bitrates"]["hls"]

--- a/resources/lib/channels/fr/weo.py
+++ b/resources/lib/channels/fr/weo.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(
-        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua}, max_age=-1)
+        URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(resp.text)[0]
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  live_id,

--- a/resources/lib/channels/jp/japanetshoppingdx.py
+++ b/resources/lib/channels/jp/japanetshoppingdx.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     data_account = re.compile(r'data-account\'\,\'(.*?)\'').findall(
         resp.text)[0]

--- a/resources/lib/channels/jp/ntvnews24.py
+++ b/resources/lib/channels/jp/ntvnews24.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     data_account = ''
     data_player = ''

--- a/resources/lib/channels/jp/tver.py
+++ b/resources/lib/channels/jp/tver.py
@@ -110,7 +110,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     stream_datas = resp.text.split('addPlayer(')[1].split(');')[0].replace(
         "\n", "").replace("\r", "").split(',')

--- a/resources/lib/channels/jp/weathernewsjp.py
+++ b/resources/lib/channels/jp/weathernewsjp.py
@@ -51,7 +51,7 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE_JSON,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     json_parser = json.loads(resp.text)
     return resolver_proxy.get_stream_youtube(plugin, json_parser["code"])

--- a/resources/lib/channels/nl/at5.py
+++ b/resources/lib/channels/nl/at5.py
@@ -171,6 +171,6 @@ def live_entry(plugin, item_id, item_dict, **kwargs):
 def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     return re.compile(r'videoStream\"\:\"(.*?)\"').findall(resp.text)[0]

--- a/resources/lib/channels/pl/tvp.py
+++ b/resources/lib/channels/pl/tvp.py
@@ -80,7 +80,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         final_language = item_dict['language']
 
     resp = urlquick.get(URL_LIVE,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     root = resp.parse()
 
@@ -105,6 +105,6 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         # Add Notification
         return False
     lives_html = urlquick.get(URL_STREAM % live_id,
-                              headers={'User-Agent': web_utils.get_random_ua},
+                              headers={'User-Agent': web_utils.get_random_ua()},
                               max_age=-1)
     return re.compile(r'src:\'(.*?)\'').findall(lives_html.text)[0]

--- a/resources/lib/channels/uk/blaze.py
+++ b/resources/lib/channels/uk/blaze.py
@@ -100,7 +100,7 @@ def list_programs(plugin, item_id, **kwargs):
 @Route.register
 def list_seasons(plugin, item_id, program_url, **kwargs):
 
-    resp = urlquick.get(program_url, headers={"User-Agent": web_utils.get_random_ua})
+    resp = urlquick.get(program_url, headers={"User-Agent": web_utils.get_random_ua()})
     root = resp.parse("ul", attrs={"class": "nav nav-tabs"})
 
     for season_datas in root.iterfind(".//h3"):

--- a/resources/lib/channels/uk/bristoltv.py
+++ b/resources/lib/channels/uk/bristoltv.py
@@ -137,7 +137,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]',
                           re.DOTALL).findall(resp.text)[0]
@@ -154,7 +154,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
     """Get video URL and start video player"""
 
     resp = urlquick.get(URL_ROOT,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]',
                          re.DOTALL).findall(resp.text)[0]

--- a/resources/lib/channels/wo/euronews.py
+++ b/resources/lib/channels/wo/euronews.py
@@ -67,7 +67,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         url_live_json = URL_LIVE_API % final_language.lower()
 
     resp = urlquick.get(url_live_json,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     json_parser = json.loads(resp.text)
     if 'http' in json_parser["url"]:
@@ -76,7 +76,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         url2_live_json = 'https:' + json_parser["url"]
 
     resp2 = urlquick.get(url2_live_json,
-                         headers={'User-Agent': web_utils.get_random_ua},
+                         headers={'User-Agent': web_utils.get_random_ua()},
                          max_age=-1)
     json_parser_2 = json.loads(resp2.text)
     return json_parser_2["primary"]

--- a/resources/lib/channels/wo/tivi5monde.py
+++ b/resources/lib/channels/wo/tivi5monde.py
@@ -191,7 +191,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     stream_url = re.compile('contentUrl\"\: \"(.*?)\"').findall(resp.text)[0]
 
@@ -213,7 +213,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         if item_id == channel_name:
             live_id = live_id_value
     resp = urlquick.get(URL_TV5MONDE_LIVE + '%s.html' % live_id,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     live_json = re.compile(r'data-broadcast=\'(.*?)\'').findall(resp.text)[0]
     json_parser = json.loads(live_json)

--- a/resources/lib/channels/wo/tv5monde.py
+++ b/resources/lib/channels/wo/tv5monde.py
@@ -207,7 +207,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_json = re.compile('data-broadcast=\'(.*?)\'').findall(resp.text)[0]
     json_parser = json.loads(video_json)
@@ -231,7 +231,7 @@ def get_live_url(plugin, item_id, video_id, item_dict, **kwargs):
         if item_id == channel_name:
             live_id = live_id_value
     resp = urlquick.get(URL_TV5MONDE_LIVE + '%s.html' % live_id,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     live_json = re.compile(r'data-broadcast=\'(.*?)\'').findall(resp.text)[0]
     json_parser = json.loads(live_json)

--- a/resources/lib/channels/wo/tv5mondeafrique.py
+++ b/resources/lib/channels/wo/tv5mondeafrique.py
@@ -203,7 +203,7 @@ def get_video_url(plugin,
                   **kwargs):
 
     resp = urlquick.get(video_url,
-                        headers={'User-Agent': web_utils.get_random_ua},
+                        headers={'User-Agent': web_utils.get_random_ua()},
                         max_age=-1)
     video_json = re.compile('data-broadcast=\'(.*?)\'').findall(resp.text)[0]
     json_parser = json.loads(video_json)

--- a/resources/lib/resolver_proxy.py
+++ b/resources/lib/resolver_proxy.py
@@ -124,14 +124,14 @@ def get_stream_vimeo(plugin,
     if referer is not None:
         html_vimeo = urlquick.get(url_vimeo,
                                   headers={
-                                      'User-Agent': web_utils.get_random_ua,
+                                      'User-Agent': web_utils.get_random_ua(),
                                       'Referer': referer
                                   },
                                   max_age=-1)
     else:
         html_vimeo = urlquick.get(
             url_vimeo,
-            headers={'User-Agent': web_utils.get_random_ua},
+            headers={'User-Agent': web_utils.get_random_ua()},
             max_age=-1)
     json_vimeo = json.loads(
         '{' +
@@ -182,7 +182,7 @@ def get_brightcove_video_json(plugin,
         URL_BRIGHTCOVE_VIDEO_JSON % (data_account, data_video_id),
         headers={
             'User-Agent':
-            web_utils.get_random_ua,
+            web_utils.get_random_ua(),
             'Accept':
             'application/json;pk=%s' %
             (get_brightcove_policy_key(data_account, data_player))
@@ -313,7 +313,7 @@ def get_francetv_video_stream(plugin,
     if drm:
         file_prgm2 = urlquick.get(
             URL_FRANCETV_HDFAUTH_URL % (url_selected),
-            headers={'User-Agent': web_utils.get_random_ua},
+            headers={'User-Agent': web_utils.get_random_ua()},
             max_age=-1)
         json_parser3 = json.loads(file_prgm2.text)
         url_selected = json_parser3['url']
@@ -326,7 +326,7 @@ def get_francetv_video_stream(plugin,
     if 'cloudreplayfrancetv' in url_selected:
         file_prgm2 = urlquick.get(
             URL_FRANCETV_HDFAUTH_URL % (url_selected),
-            headers={'User-Agent': web_utils.get_random_ua},
+            headers={'User-Agent': web_utils.get_random_ua()},
             max_age=-1)
         json_parser3 = json.loads(file_prgm2.text)
         url_selected = json_parser3['url']

--- a/resources/lib/websites/culturepub.py
+++ b/resources/lib/websites/culturepub.py
@@ -145,7 +145,7 @@ def get_video_url(plugin,
 
     info_video_html = urlquick.get(video_url,
                                    headers={
-                                       'User-Agent': web_utils.get_random_ua
+                                       'User-Agent': web_utils.get_random_ua()
                                    },
                                    max_age=-1).text
     video_id = re.compile('player=7&pod=(.*?)[\"\&]').findall(


### PR DESCRIPTION
Missing parentheses on `get_random_ua` calls which cause headers to end up like this:

```
{ 
   "Accept-language":"en-gb,en-us,en",
   "Accept-Encoding":"gzip, deflate",
   "Host":"edge.api.brightcove.com",
   "Accept":"application/json;pk=BCpkADawqM1iwEgtqPGpn00-wo0b6i9Ki0TLO2j1xrVJmqm2G5QkRf9pO95HjEdSmnbDVs0bJ1QvKSxBNgI5efql9-BDLiipQjW-GaFw4_QPFuo5SZnUocYV8vch17gYtoS9dEhkldDS8Z41",
   "User-Agent":"<function get_random_ua at 0x000001B159B8D7B8>",
   "Connection":"keep-alive"
}
```