### PR TITLE
Use JSON file for Favourites instead of pickled data

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.catchuptvandmore"
        name="Catch-up TV &amp; More"
-       version="0.2.17~beta03"
+       version="0.2.17~beta04"
        provider-name="SylvainCecchetto,wwark">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
@@ -47,6 +47,7 @@
 [Fix] Live TV - NTV (CA)
 [Fix] Live TV - Sport En France (FR)
 [Fix] Live TV and Catchup TV - CNews (FR)
+[Improvement] Favourites - Migrate from pickled to json data
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/resources/lib/listitem_utils.py
+++ b/resources/lib/listitem_utils.py
@@ -45,13 +45,13 @@ def item2dict(item):
     # https://scriptmodulecodequick.readthedocs.io/en/latest/_modules/codequick/listing.html#Listitem.from_dict
     # in order to be able to directly use `Listitem.from_dict` later
     item_dict = {}
-    item_dict['subtitles'] = item.subtitles
+    item_dict['subtitles'] = list(item.subtitles)
     item_dict['art'] = dict(item.art)
     item_dict['info'] = dict(item.info)
     item_dict['stream'] = dict(item.stream)
     item_dict['context'] = list(item.context)
     item_dict['properties'] = dict(item.property)
-    item_dict['params'] = item.params
+    item_dict['params'] = dict(item.params)
     item_dict['label'] = item.label
     return item_dict
 


### PR DESCRIPTION
Hey @wwark (et éventuellement @Psychoses),

Ce PR permet (normalement) de stocker les favoris dans un JSON à la place du fichier pickle.
J'ai essayé en XML mais trop la galère ...

Normalement j'ai aussi fait en sorte que la migration des favoris existant puisse se faire, mais ce point est encore à confirmer ...

Est-ce que si vous avez des favoris existants vous pouvez essayer le test suivant :

1. **Faire un backup du fichier `favourites.pickle`**
2. Appliquer la branche `favourites_json`
3. Accéder à vos Favoris (ou bien ajouter un nouveau favoris)
4. Remarquer que le fichier `favourites.pickle` a été supprimé et qu'un nouveau fichier `favourites.json` a été créé et contient vos anciens favoris
5. Essayer de jouer un peu avec les favoris (Ajouts, suppressions, renommage, Monter, Descendre, ...)

Merci d'avance pour vos tests !!
