### PR TITLE
Add auvio main TV channels

### DIFF
--- a/plugin.video.catchuptvandmore/resources/lib/labels.py
+++ b/plugin.video.catchuptvandmore/resources/lib/labels.py
@@ -399,6 +399,12 @@ def save_labels_in_mem_storage():
         # Belgium channels / live TV
         'auvio':
         'RTBF Auvio',
+        'laune':
+        'La Une',
+        'ladeux':
+        'La Deux',
+        'latrois':
+        'La Trois',
         'brf':
         'BRF Mediathek',
         'rtl_tvi':

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/be_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/be_live.py
@@ -93,33 +93,6 @@ menu = {
         'enabled': True,
         'order': 8
     },
-    'laune': {
-        'callback': 'live_bridge',
-        'thumb': 'channels/be/laune.jpg',
-        'fanart': 'channels/be/laune_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
-        'xmltv_id': 'C164.api.telerama.fr',
-        'enabled': True,
-        'order': 9
-    },
-    'ladeux': {
-        'callback': 'live_bridge',
-        'thumb': 'channels/be/ladeux.jpg',
-        'fanart': 'channels/be/ladeux_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
-        'xmltv_id': 'C187.api.telerama.fr',
-        'enabled': True,
-        'order': 10
-    },
-    'latrois': {
-        'callback': 'live_bridge',
-        'thumb': 'channels/be/latrois.jpg',
-        'fanart': 'channels/be/latrois_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
-        'xmltv_id': 'C892.api.telerama.fr',
-        'enabled': True,
-        'order': 11
-    },
     'tvlux': {
         'callback': 'live_bridge',
         'thumb': 'channels/be/tvlux.png',
@@ -127,7 +100,7 @@ menu = {
         'module': 'resources.lib.channels.be.tvlux',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 12
+        'order': 9
     },
     'rtl_info': {
         'callback': 'live_bridge',
@@ -136,7 +109,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 13
+        'order': 10
     },
     'bel_rtl': {
         'callback': 'live_bridge',
@@ -145,7 +118,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 14
+        'order': 11
     },
     'contact': {
         'callback': 'live_bridge',
@@ -154,7 +127,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr Radio',
         'enabled': True,
-        'order': 15
+        'order': 12
     },
     'bx1': {
         'callback': 'live_bridge',
@@ -163,7 +136,7 @@ menu = {
         'module': 'resources.lib.channels.be.bx1',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 16
+        'order': 13
     },
     'een': {
         'callback': 'live_bridge',
@@ -173,7 +146,7 @@ menu = {
         'xmltv_id': 'C23.api.telerama.fr',
         'm3u_group': 'België nl',
         'enabled': True,
-        'order': 17
+        'order': 14
     },
     'canvas': {
         'callback': 'live_bridge',
@@ -182,7 +155,7 @@ menu = {
         'module': 'resources.lib.channels.be.vrt',
         'm3u_group': 'België nl',
         'enabled': True,
-        'order': 18
+        'order': 15
     },
     'ketnet': {
         'callback': 'live_bridge',
@@ -192,7 +165,7 @@ menu = {
         'xmltv_id': 'C1280.api.telerama.fr',
         'm3u_group': 'België nl',
         'enabled': True,
-        'order': 19
+        'order': 16
     },
     'nrjhitstvbe': {
         'callback': 'live_bridge',
@@ -201,7 +174,7 @@ menu = {
         'module': 'resources.lib.channels.be.nrjhitstvbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 20
+        'order': 17
     },
     'rtl_sport': {
         'callback': 'live_bridge',
@@ -210,7 +183,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 21
+        'order': 18
     },
     'tvcom': {
         'callback': 'live_bridge',
@@ -219,7 +192,7 @@ menu = {
         'module': 'resources.lib.channels.be.tvcom',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 22
+        'order': 19
     },
     'canalc': {
         'callback': 'live_bridge',
@@ -228,7 +201,7 @@ menu = {
         'module': 'resources.lib.channels.be.canalc',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 23
+        'order': 20
     },
     'abxplore': {
         'callback': 'live_bridge',
@@ -237,7 +210,7 @@ menu = {
         'module': 'resources.lib.channels.be.abbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 24
+        'order': 21
     },
     'ab3': {
         'callback': 'live_bridge',
@@ -246,7 +219,7 @@ menu = {
         'module': 'resources.lib.channels.be.abbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 25
+        'order': 22
     },
     'ln24': {
         'callback': 'live_bridge',
@@ -254,6 +227,33 @@ menu = {
         'fanart': 'channels/be/ln24_fanart.jpg',
         'module': 'resources.lib.channels.be.ln24',
         'm3u_group': 'Belgique fr',
+        'enabled': True,
+        'order': 23
+    },
+    'laune': {
+        'callback': 'live_bridge',
+        'thumb': 'channels/be/laune.jpg',
+        'fanart': 'channels/be/laune_fanart.jpg',
+        'module': 'resources.lib.channels.be.rtbf',
+        'xmltv_id': 'C164.api.telerama.fr',
+        'enabled': True,
+        'order': 24
+    },
+    'ladeux': {
+        'callback': 'live_bridge',
+        'thumb': 'channels/be/ladeux.jpg',
+        'fanart': 'channels/be/ladeux_fanart.jpg',
+        'module': 'resources.lib.channels.be.rtbf',
+        'xmltv_id': 'C187.api.telerama.fr',
+        'enabled': True,
+        'order': 25
+    },
+    'latrois': {
+        'callback': 'live_bridge',
+        'thumb': 'channels/be/latrois.jpg',
+        'fanart': 'channels/be/latrois_fanart.jpg',
+        'module': 'resources.lib.channels.be.rtbf',
+        'xmltv_id': 'C892.api.telerama.fr',
         'enabled': True,
         'order': 26
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/be_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/be_live.py
@@ -93,6 +93,33 @@ menu = {
         'enabled': True,
         'order': 8
     },
+    'laune': {
+        'callback': 'live_bridge',
+        'thumb': 'channels/be/laune.jpg',
+        'fanart': 'channels/be/laune_fanart.jpg',
+        'module': 'resources.lib.channels.be.rtbf',
+        'xmltv_id': 'C164.api.telerama.fr',
+        'enabled': True,
+        'order': 9
+    },
+    'ladeux': {
+        'callback': 'live_bridge',
+        'thumb': 'channels/be/ladeux.jpg',
+        'fanart': 'channels/be/ladeux_fanart.jpg',
+        'module': 'resources.lib.channels.be.rtbf',
+        'xmltv_id': 'C187.api.telerama.fr',
+        'enabled': True,
+        'order': 10
+    },
+    'latrois': {
+        'callback': 'live_bridge',
+        'thumb': 'channels/be/latrois.jpg',
+        'fanart': 'channels/be/latrois_fanart.jpg',
+        'module': 'resources.lib.channels.be.rtbf',
+        'xmltv_id': 'C892.api.telerama.fr',
+        'enabled': True,
+        'order': 11
+    },
     'tvlux': {
         'callback': 'live_bridge',
         'thumb': 'channels/be/tvlux.png',
@@ -100,7 +127,7 @@ menu = {
         'module': 'resources.lib.channels.be.tvlux',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 9
+        'order': 12
     },
     'rtl_info': {
         'callback': 'live_bridge',
@@ -109,7 +136,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 10
+        'order': 13
     },
     'bel_rtl': {
         'callback': 'live_bridge',
@@ -118,7 +145,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 11
+        'order': 14
     },
     'contact': {
         'callback': 'live_bridge',
@@ -127,7 +154,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr Radio',
         'enabled': True,
-        'order': 12
+        'order': 15
     },
     'bx1': {
         'callback': 'live_bridge',
@@ -136,7 +163,7 @@ menu = {
         'module': 'resources.lib.channels.be.bx1',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 13
+        'order': 16
     },
     'een': {
         'callback': 'live_bridge',
@@ -146,7 +173,7 @@ menu = {
         'xmltv_id': 'C23.api.telerama.fr',
         'm3u_group': 'België nl',
         'enabled': True,
-        'order': 14
+        'order': 17
     },
     'canvas': {
         'callback': 'live_bridge',
@@ -155,7 +182,7 @@ menu = {
         'module': 'resources.lib.channels.be.vrt',
         'm3u_group': 'België nl',
         'enabled': True,
-        'order': 15
+        'order': 18
     },
     'ketnet': {
         'callback': 'live_bridge',
@@ -165,7 +192,7 @@ menu = {
         'xmltv_id': 'C1280.api.telerama.fr',
         'm3u_group': 'België nl',
         'enabled': True,
-        'order': 16
+        'order': 19
     },
     'nrjhitstvbe': {
         'callback': 'live_bridge',
@@ -174,7 +201,7 @@ menu = {
         'module': 'resources.lib.channels.be.nrjhitstvbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 17
+        'order': 20
     },
     'rtl_sport': {
         'callback': 'live_bridge',
@@ -183,7 +210,7 @@ menu = {
         'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 18
+        'order': 21
     },
     'tvcom': {
         'callback': 'live_bridge',
@@ -192,7 +219,7 @@ menu = {
         'module': 'resources.lib.channels.be.tvcom',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 19
+        'order': 22
     },
     'canalc': {
         'callback': 'live_bridge',
@@ -201,7 +228,7 @@ menu = {
         'module': 'resources.lib.channels.be.canalc',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 20
+        'order': 23
     },
     'abxplore': {
         'callback': 'live_bridge',
@@ -210,7 +237,7 @@ menu = {
         'module': 'resources.lib.channels.be.abbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 21
+        'order': 24
     },
     'ab3': {
         'callback': 'live_bridge',
@@ -219,7 +246,7 @@ menu = {
         'module': 'resources.lib.channels.be.abbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 22
+        'order': 25
     },
     'ln24': {
         'callback': 'live_bridge',
@@ -228,6 +255,6 @@ menu = {
         'module': 'resources.lib.channels.be.ln24',
         'm3u_group': 'Belgique fr',
         'enabled': True,
-        'order': 23
+        'order': 26
     }
 }

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_all.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_all.m3u
@@ -1063,6 +1063,21 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=a
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ab3.png" group-title="Belgium",AB3
 plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ab3&item_module=resources.lib.channels.be.abbe&item_dict={}
 
+## La Une
+## laune
+#EXTINF:-1 tvg-id="C164.api.telerama.fr" tvg-logo="https://github.com/Catch-up-TV-and-More/images/raw/master/channels/be/laune.jpg" group-title="Belgium",La Une
+plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=laune&item_module=resources.lib.channels.be.rtbf&item_dict={}
+
+## La Deux
+## ladeux
+#EXTINF:-1 tvg-id="C187.api.telerama.fr" tvg-logo="https://github.com/Catch-up-TV-and-More/images/raw/master/channels/be/ladeux.jpg" group-title="Belgium",La Deux
+plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ladeux&item_module=resources.lib.channels.be.rtbf&item_dict={}
+
+## La Trois
+## latrois
+#EXTINF:-1 tvg-id="C892.api.telerama.fr" tvg-logo="https://github.com/Catch-up-TV-and-More/images/raw/master/channels/be/latrois.jpg" group-title="Belgium",La Trois
+plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=latrois&item_module=resources.lib.channels.be.rtbf&item_dict={}
+
 ##	LN24
 ##	ln24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ln24.png" group-title="Belgium",LN24

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_be.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_be.m3u
@@ -98,6 +98,21 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=a
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ab3.png" group-title="Belgium Belgique fr",AB3
 plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ab3&item_module=resources.lib.channels.be.abbe&item_dict={}
 
+## La Une
+## laune
+#EXTINF:-1 tvg-id="C164.api.telerama.fr" tvg-logo="https://github.com/Catch-up-TV-and-More/images/raw/master/channels/be/laune.jpg" group-title="Belgium Belgique fr",La Une
+plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=laune&item_module=resources.lib.channels.be.rtbf&item_dict={}
+
+## La Deux
+## ladeux
+#EXTINF:-1 tvg-id="C187.api.telerama.fr" tvg-logo="https://github.com/Catch-up-TV-and-More/images/raw/master/channels/be/ladeux.jpg" group-title="Belgium Belgique fr",La Deux
+plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ladeux&item_module=resources.lib.channels.be.rtbf&item_dict={}
+
+## La Trois
+## latrois
+#EXTINF:-1 tvg-id="C892.api.telerama.fr" tvg-logo="https://github.com/Catch-up-TV-and-More/images/raw/master/channels/be/latrois.jpg" group-title="Belgium Belgique fr",La Trois
+plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=latrois&item_module=resources.lib.channels.be.rtbf&item_dict={}
+
 ##	LN24
 ##	ln24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ln24.png" group-title="Belgium Belgique fr",LN24


### PR DESCRIPTION
Hello,

I wanted to be able to get the main auvio TV channels in the TV Guide (La Une, La Deux and La Trois), so I have changed the files to have a live_bridge for auvio main TV channels. So they are now directly in the be folder and in the auvio folder. I have kept the auvio folder because it contains exclusive contents and live radio channel.

For the change to work, it will request to load as well the channels images in the https://github.com/Catch-up-TV-and-More/images repository 

You can find the channel pictures here: http://www.rtbf.be/api/partner/generic/epg/channellist?v=7&type=tv&partner_key=82ed2c5b7df0a9334dfbda21eccd8427

In the different files I've named the pictures laune.jpg and laune_fanart.jpg (same for other channels but with ladeux and latrois)

Let me know what you think about it.

Regards,

Gaet81