### PR TITLE
Kill bridge functions thanks to CodeQuick 0.9.13

### DIFF
--- a/plugin.video.catchuptvandmore/addon.xml
+++ b/plugin.video.catchuptvandmore/addon.xml
@@ -2,7 +2,7 @@
 <addon id="plugin.video.catchuptvandmore" name="Catch-up TV &amp; More" version="0.2.25~beta05" provider-name="SylvainCecchetto,wwark">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
-    <import addon="script.module.codequick" version="0.9.12"/>
+    <import addon="script.module.codequick" version="0.9.13"/>
     <import addon="script.module.youtube.dl" version="18.225.0"/>
     <import addon="script.module.requests" version="2.12.4"/>
     <import addon="script.module.pytz" version="2014.2"/>
@@ -52,6 +52,7 @@
 [BE - RTLplay] Move all RTL group channels in RTLplay folder
 [BE - RTBF] Fix Live TV with no audio (DRM)
 [CH - RTS] Fix Live TV with no audio (DRM)
+[Core] Bump CodeQuick 0.9.13 - Kill xxxx_bridge functions
 ----
 Visit WebSite - http://mpdb.tv/#home which host the french forum used by users of CU TV and More
     </news>

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/abbe.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/abbe.py
@@ -49,12 +49,8 @@ URL_LIVES = URL_ROOT + '/Live-Replay/'
 # channel (lucky jack, ...)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     # Live TV Not working / find a way to dump html received
 

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/actv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/actv.py
@@ -49,12 +49,8 @@ URL_LIVE = URL_ROOT + '/direct'
 URL_STREAM = 'https://actv.fcst.tv/player/embed/%s'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     live_id = re.compile(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/brf.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/brf.py
@@ -42,13 +42,6 @@ import urlquick
 URL_ROOT_BRF = 'https://m.brf.be/'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/bx1.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/bx1.py
@@ -45,13 +45,6 @@ URL_LIVE = URL_ROOT + '/lives/direct-tv/'
 URL_EMISSIONS = URL_ROOT + '/emissions'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
 
@@ -122,12 +115,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     return re.compile(r'"file": "(.*?)"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/canalc.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/canalc.py
@@ -52,13 +52,6 @@ URL_LIVE = URL_ROOT + '/live/'
 URL_EMISSIONS = URL_ROOT + '/nos-emissions-2/'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
 
@@ -165,12 +158,8 @@ def get_video_url(plugin,
         return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     return unquote_plus(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/ln24.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/ln24.py
@@ -47,12 +47,8 @@ URL_ROOT = 'https://www.ln24.be'
 URL_LIVE = URL_ROOT + '/direct'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     return re.compile(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/nrjhitstvbe.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/nrjhitstvbe.py
@@ -47,13 +47,6 @@ URL_STREAM = 'https://services.brid.tv/services/get/video/%s/%s.json'
 URL_VIDEOS = URL_ROOT + '/replay/videos'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_videos(plugin, item_id)
-
-
 @Route.register
 def list_videos(plugin, item_id, **kwargs):
 
@@ -99,12 +92,8 @@ def get_video_url(plugin,
     return 'https:' + json_parser2["Video"][0]["source"]["hd"]
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     data_player = re.compile(r'data-video-player-id\=\"(.*?)\"').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf.py
@@ -117,13 +117,6 @@ def format_day(date, **kwargs):
     return date_dmy
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
 
@@ -385,22 +378,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def multi_live_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_lives(plugin, item_id)
-
-
-def live_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after live_bridge
-    """
-    return set_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def set_live_url(plugin, item_id, video_id, **kwargs):
+def set_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_JSON_LIVE_CHANNEL % (item_id, get_partener_key()), max_age=-1)
     json_parser = json.loads(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/rtc.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/rtc.py
@@ -49,13 +49,6 @@ URL_VIDEOS = URL_ROOT + '/videos'
 URL_EMISSIONS = URL_ROOT + '/emissions'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -151,12 +144,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     root = resp.parse()

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe.py
@@ -499,12 +499,8 @@ def get_video_url(plugin,
         return False
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if get_kodi_version() < 18:
         xbmcgui.Dialog().ok('Info', plugin.localize(30602))

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/telemb.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/telemb.py
@@ -49,13 +49,6 @@ URL_STREAM_LIVE = 'https://telemb.fcst.tv/player/embed/%s'
 # LiveId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
 
@@ -124,12 +117,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     live_id = re.compile(r'telemb.fcst.tv/player/embed\/(.*?)[\?\"]').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/tvcom.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/tvcom.py
@@ -48,13 +48,6 @@ URL_VIDEOS = URL_ROOT + '/videos'
 URL_EMISSIONS = URL_ROOT + '/emissions'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -150,12 +143,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     return re.compile(r'sourceURL\"\:\"(.*?)\"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/tvlux.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/tvlux.py
@@ -48,13 +48,6 @@ URL_VIDEOS = URL_ROOT + '/videos'
 URL_EMISSIONS = URL_ROOT + '/emissions'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -149,12 +142,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     return re.compile(r'"sourceURL":"(.*?)"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/be/vrt.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/be/vrt.py
@@ -78,13 +78,6 @@ def get_api_key():
     return '3_qhEcPa5JGFROVwu5SWKqJ4mVOIkwlFNMSKwzPDAh8QZOtHqu6L4nD5Q7lk0eXOOG'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_root(plugin, item_id)
-
-
 @Route.register
 def list_root(plugin, item_id, **kwargs):
     """
@@ -289,12 +282,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.post(URL_TOKEN_LIVE, max_age=-1)
     json_parser_token = json.loads(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc.py
@@ -60,12 +60,8 @@ LIVE_CBC_REGIONS = {
 }
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     final_region = kwargs.get('language', Script.setting['cbc.language'])
     region = utils.ensure_unicode(final_region)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele.py
@@ -73,13 +73,6 @@ LIVE_ICI_TELE_REGIONS = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
 
@@ -159,12 +152,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp2 = urlquick.get(
         URL_CLIENT_VALUE,

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/icitoutv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/icitoutv.py
@@ -65,13 +65,6 @@ URL_CLIENT_KEY_VIDEO_JS = URL_ROOT + '/media/player/client/toutv_beta'
 # TODO Get client key for
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
 

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/noovo.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/noovo.py
@@ -55,13 +55,6 @@ URL_LIVE_INFOS = URL_ROOT + '/dist/js/noovo.%s.js'
 # Id
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -168,12 +161,8 @@ def get_video_url(plugin,
                                                     download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={'User-Agent': web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/ntvca.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/ntvca.py
@@ -42,12 +42,8 @@ URL_ROOT = 'http://ntv.ca'
 URL_LIVE = URL_ROOT + '/web-tv/'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     root = resp.parse()

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/telemag.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/telemag.py
@@ -43,13 +43,6 @@ URL_ROOT = 'http://tele-mag.tv'
 URL_EMISSIONS = URL_ROOT + '/emission/emissions'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -119,12 +112,8 @@ def get_video_url(plugin,
         return False
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT)
     root = resp.parse()

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/telequebec.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/telequebec.py
@@ -48,13 +48,6 @@ URL_STREAM = 'https://mnmedias.api.telequebec.tv/m3u8/%s.m3u8'
 # VideoId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -119,12 +112,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     list_live_datas = re.compile(r'liveGPManifestUrl:"(.*?)"').findall(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/tv5unis.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/tv5unis.py
@@ -57,13 +57,6 @@ URL_STREAM = URL_ROOT + '/videos/%s'
 # slug_video
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ca/tva.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ca/tva.py
@@ -56,13 +56,6 @@ URL_VIDEOS = URL_ROOT + '/page/rattrapage'
 URL_SEARCH = URL_ROOT + '/search'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -226,12 +219,8 @@ def get_video_url(plugin,
                                                     download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     json_parser = json.loads(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ch/becurioustv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ch/becurioustv.py
@@ -44,13 +44,6 @@ URL_ROOT = 'https://becurious.ch'
 URL_VIDEOS = URL_ROOT + '/?infinity=scrolling'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ch/lemanbleu.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ch/lemanbleu.py
@@ -57,13 +57,6 @@ URL_VIDEOS = URL_ROOT + '/Scripts/Modules/CustomView/List.aspx?idn=9667&name=Rep
 QUALITIES_STREAM = ['sd', 'md', 'hq', 'hd']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -169,12 +162,8 @@ def get_video_url(plugin,
     return url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     player_id = re.compile(r'\&player\=(.*?)\"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ch/rougetv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ch/rougetv.py
@@ -42,12 +42,8 @@ URL_ROOT = 'http://www.rouge.com'
 URL_LIVE = URL_ROOT + '/rouge-tv-live'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     return re.compile('streaming_url = \'(.*?)\'').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr.py
@@ -107,13 +107,6 @@ SWISSINFO_TOPICS = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -382,12 +375,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_JSON % item_id[:3])
     json_parser = json.loads(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ch/telem1.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ch/telem1.py
@@ -42,12 +42,8 @@ URL_ROOT = 'https://www.telem1.ch'
 URL_LIVE = URL_ROOT + '/live'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     list_lives = re.compile(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ch/teleticino.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ch/teleticino.py
@@ -42,12 +42,8 @@ URL_ROOT = 'http://teleticino.ch'
 URL_LIVE = URL_ROOT + '/diretta'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     list_lives = re.compile(r'file":  "(.*?)"').findall(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/ch/tvm3.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/ch/tvm3.py
@@ -48,13 +48,6 @@ URL_STREAM = 'https://livevideo.infomaniak.com/iframe.php?stream=tvm3&name=html5
 # player_id
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -136,12 +129,8 @@ def get_video_url(plugin,
         return resolver_proxy.get_stream_vimeo(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/cm/crtv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/cm/crtv.py
@@ -45,12 +45,8 @@ URL_ROOT = 'http://www.crtv.cm'
 URL_LIVE = URL_ROOT + '/live-%s/'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE % item_id, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv.py
@@ -56,12 +56,8 @@ def get_ip():
     return IP
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     live_id = 'cctv_p2p_hd%s' % item_id
     resp = requests.get(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/es/atresplayer.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/es/atresplayer.py
@@ -247,12 +247,8 @@ def get_video_url(plugin,
     return False
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/es/mitele.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/es/mitele.py
@@ -69,13 +69,6 @@ LIST_PROGRAMS = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -236,12 +229,8 @@ def get_video_url(plugin,
     return url_stream + '?' + json_parser4["tokens"]["2"]["cdn"]
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     session_requests = requests.session()
     resp = session_requests.get(URL_LIVE_DATAS % item_id)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/es/paramountchannel_es.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/es/paramountchannel_es.py
@@ -40,12 +40,8 @@ import urlquick
 URL_LIVE = 'http://www.paramountnetwork.es/en-directo/4ypes1'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     video_uri = re.compile(r'\"config"\:\{\"uri\"\:\"(.*?)\"').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/es/realmadridtv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/es/realmadridtv.py
@@ -42,12 +42,8 @@ URL_ROOT = 'https://www.realmadrid.com'
 URL_LIVE = URL_ROOT + '/real-madrid-tv'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     url_live = ''
     final_language = kwargs.get('language', Script.setting['realmadridtv.language'])

--- a/plugin.video.catchuptvandmore/resources/lib/channels/et/video2b.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/et/video2b.py
@@ -34,7 +34,7 @@ import urlquick
 
 
 @Resolver.register
-def live_entry(plugin, item_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
     html = urlquick.get('http://video2b.vixtream.net/tv/v/%s' % item_id).text.encode('utf-8')
     m3u8_url = re.compile(r'var src=\'(.*?)\';').findall(html)
     if m3u8_url:

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/01net.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/01net.py
@@ -40,12 +40,8 @@ URL_ROOT = 'https://www.01net.com'
 URL_LIVE = URL_ROOT + '/01tv/'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/6play.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/6play.py
@@ -109,13 +109,6 @@ URL_LIVE_JSON = 'https://pc.middleware.6play.fr/6play/v2/platforms/m6group_web/s
 DESIRED_QUALITY = Script.setting['quality']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return sixplay_root(plugin)
-
-
 @Route.register
 def sixplay_root(plugin, **kwargs):
 
@@ -523,12 +516,8 @@ def get_playlist_urls(plugin,
         return playlist_videos
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if item_id == 'fun_radio' or \
             item_id == 'rtl2' or \

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/abweb.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/abweb.py
@@ -49,12 +49,8 @@ URL_LIVES = URL_ROOT + '/BIS-TV-Online/bistvo-tele-universal.aspx'
 # channel (lucky jack, ...)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     # Live TV Not working / find a way to dump html received
 

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/alsace20.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/alsace20.py
@@ -46,13 +46,6 @@ URL_ROOT = "https://www.alsace20.tv"
 URL_LIVE = URL_ROOT + "/emb/live1"
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -193,12 +186,8 @@ def get_video_url(plugin,
     return item
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     is_helper = inputstreamhelper.Helper('mpd')
     if not is_helper.check_inputstream():

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/antennereunion.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/antennereunion.py
@@ -53,13 +53,6 @@ CATEGORIES = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -130,12 +123,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     live_html = urlquick.get(URL_LIVE,
                              headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/azurtv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/azurtv.py
@@ -43,12 +43,8 @@ URL_ROOT = "https://www.%s-tv.fr"
 URL_LIVE = URL_ROOT + "/live/"
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if 'provenceazur' in item_id:
         resp = urlquick.get(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion.py
@@ -48,13 +48,6 @@ URL_LIVE_BFM_REGION = URL_ROOT_REGION + '/en-direct/'
 URL_REPLAY_BFM_REGION = URL_ROOT_REGION + '/videos/?page=%s'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -127,12 +120,8 @@ def get_video_url(plugin,
                                                     download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if 'paris' in item_id:
         resp = urlquick.get(URL_ROOT + '/mediaplayer/live-bfm-paris/',

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmtv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmtv.py
@@ -74,13 +74,6 @@ URL_LIVE_BFMBUSINESS = 'http://bfmbusiness.bfmtv.com/mediaplayer/live-video/'
 DESIRED_QUALITY = Script.setting['quality']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 def get_token(item_id):
     """Get session token"""
     resp = urlquick.get(URL_TOKEN % item_id)
@@ -225,12 +218,8 @@ def get_video_url(plugin,
         return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if item_id == 'bfmtv':
         resp = urlquick.get(URL_LIVE_BFMTV,

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/biptv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/biptv.py
@@ -43,12 +43,8 @@ URL_ROOT = "http://www.biptv.tv"
 URL_LIVE = URL_ROOT + "/direct.html"
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/caledonia.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/caledonia.py
@@ -42,13 +42,6 @@ import urlquick
 URL_ROOT = 'https://www.caledonia.nc'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/canal10.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/canal10.py
@@ -44,12 +44,8 @@ URL_STREAM = 'https://livevideo.infomaniak.com/player_config/%s.json'
 # player_id
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/cnews.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/cnews.py
@@ -53,13 +53,6 @@ URL_VIDEOS_CNEWS = URL_ROOT_SITE + '/service/dm_loadmore/dm_emission_index_sujet
 # num Page
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -138,12 +131,8 @@ def get_video_url(plugin,
                                                  download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_CNEWS,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/dicitv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/dicitv.py
@@ -47,12 +47,8 @@ URL_STREAM = 'https://player.infomaniak.com/playerConfig.php?channel=%s'
 # channel
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/europe1.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/europe1.py
@@ -43,12 +43,8 @@ URL_ROOT = "https://api.lejdd.fr"
 URL_LIVE = URL_ROOT + '/v2/data/live/'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions.py
@@ -95,13 +95,6 @@ CORRECT_MONTH = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -183,10 +176,6 @@ def get_video_url(plugin,
 
     return resolver_proxy.get_francetv_video_stream(plugin, id_diffusion,
                                                     download_mode)
-
-
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
 
 
 @Resolver.register

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinfo.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinfo.py
@@ -67,13 +67,6 @@ URL_INFO_OEUVRE = 'https://sivideo.webservices.francetelevisions.fr/tools/getInf
 DESIRED_QUALITY = Script.setting['quality']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -256,12 +249,8 @@ def get_video_url(plugin,
         return False
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_JSON,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinter.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinter.py
@@ -43,12 +43,8 @@ URL_ROOT = "https://www.franceinter.fr"
 URL_LIVE = URL_ROOT + '/direct'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv.py
@@ -59,16 +59,8 @@ URL_API_MOBILE = utils.urljoin_partial("https://api-mobile.yatta.francetv.fr/")
 URL_API_FRONT = utils.urljoin_partial("http://api-front.yatta.francetv.fr")
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return francetv_root(plugin)
-
-
 @Route.register
 def francetv_root(plugin, **kwargs):
-
     # Channels
     item = Listitem()
     item.label = Script.localize(30006)
@@ -409,12 +401,8 @@ def get_video_url(plugin,
                                                     download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     broadcast_id = 'SIM_France%s'
     return resolver_proxy.get_francetv_live_stream(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/francetvsport.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/francetvsport.py
@@ -50,13 +50,6 @@ URL_FRANCETV_SPORT = 'https://api-sport-events.webservices.' \
                      'francetelevisions.fr/%s'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -134,13 +127,6 @@ def get_video_url(plugin,
                                                     download_mode)
 
 
-def multi_live_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_lives(plugin, item_id)
-
-
 @Route.register
 def list_lives(plugin, item_id, **kwargs):
 
@@ -200,5 +186,4 @@ def list_lives(plugin, item_id, **kwargs):
 
 @Resolver.register
 def get_live_url(plugin, item_id, id_diffusion, **kwargs):
-
     return resolver_proxy.get_francetv_live_stream(plugin, id_diffusion)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/gameone.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/gameone.py
@@ -47,13 +47,6 @@ URL_PROGRAMS = URL_ROOT + '/shows'
 # PageId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/gong.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/gong.py
@@ -49,13 +49,6 @@ URL_VIDEOS = URL_ROOT + '/videos.php?page=%s'
 DESIRED_QUALITY = Script.setting['quality']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -109,12 +102,8 @@ def get_video_url(plugin,
     return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/gulli.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/gulli.py
@@ -91,13 +91,6 @@ def get_api_key():
     return 'iphoner_' + key
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -201,12 +194,8 @@ def get_video_url(plugin,
     return video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     url_live = ''
     live_html = urlquick.get(URL_LIVE_TV,

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/idf1.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/idf1.py
@@ -47,12 +47,8 @@ JSON_LIVE = 'https://playback.dacast.com/content/access?contentId=%s&provider=da
 # Id in 3 part
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     list_id_values = re.compile(r'contentId\=(.*?)\"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/j_one.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/j_one.py
@@ -43,13 +43,9 @@ from kodi_six import xbmcgui
 URL_REPLAY = 'https://api.dailymotion.com/user/%s/videos?fields=description,duration,id,taken_time,thumbnail_large_url,title&limit=20&sort=recent&page=1'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    url = URL_REPLAY % (item_id.replace('_', '-'))
-    return list_videos(plugin, item_id, url)
-
-
 @Route.register
-def list_videos(plugin, item_id, url, **kwargs):
+def list_videos(plugin, item_id, **kwargs):
+    url = URL_REPLAY % (item_id.replace('_', '-'))
     headers = {'User-Agent': 'Android'}
     r = urlquick.get(url, headers=headers)
     json_parser = json.loads(r.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/jack.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/jack.py
@@ -45,13 +45,6 @@ URL_API = 'https://api.canalplus.pro'
 URL_VIDEOS = URL_API + '/creativemedia/video'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/kto.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/kto.py
@@ -44,13 +44,6 @@ URL_ROOT = 'https://www.ktotv.com'
 URL_SHOWS = URL_ROOT + '/emissions'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -179,12 +172,8 @@ def get_video_url(plugin,
     return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere.py
@@ -81,13 +81,6 @@ CORRECT_MONTH = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -169,10 +162,6 @@ def get_video_url(plugin,
 
     return resolver_proxy.get_francetv_video_stream(plugin, id_diffusion,
                                                     download_mode)
-
-
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
 
 
 @Resolver.register

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/lachainemeteo.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/lachainemeteo.py
@@ -42,13 +42,6 @@ URL_VIDEOS = URL_ROOT + '/videos-meteo/videos-la-chaine-meteo'
 URL_BRIGHTCOVE_DATAS = URL_ROOT + '/jsdyn/lcmjs.js'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/lachainenormande.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/lachainenormande.py
@@ -43,12 +43,8 @@ import urlquick
 URL_ROOT = "https://www.lachainenormande.tv"
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     is_helper = inputstreamhelper.Helper('mpd')
     if not is_helper.check_inputstream():

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/lci.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/lci.py
@@ -62,13 +62,6 @@ URL_VIDEO_STREAM = 'https://www.wat.tv/get/webhtml/%s'
 DESIRED_QUALITY = Script.setting['quality']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -221,12 +214,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     video_id = 'L_%s' % item_id.upper()
 

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/lcp.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/lcp.py
@@ -60,13 +60,6 @@ CATEGORIES = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -201,12 +194,8 @@ def get_video_url(plugin,
                                                  download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_SITE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/lequipe.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/lequipe.py
@@ -48,13 +48,6 @@ URL_INFO_STREAM_LIVE = URL_ROOT + '/js/app.%s.js'
 URL_API_LEQUIPE = URL_ROOT + '/equipehd/applis/filtres/videosfiltres.json'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
 
@@ -118,12 +111,8 @@ def get_video_url(plugin,
                                                  download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/lumni.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/lumni.py
@@ -57,13 +57,6 @@ CATEGORIES_EDUCATION = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/luxetv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/luxetv.py
@@ -42,13 +42,6 @@ import urlquick
 URL_ROOT = 'https://luxe.tv/'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/mblivetv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/mblivetv.py
@@ -44,10 +44,6 @@ URL_LIVES = 'https://api.dailymotion.com/user/%s/videos?fields=id,thumbnail_larg
 URL_REPLAY = 'https://api.dailymotion.com/user/%s/videos?fields=description,duration,id,taken_time,thumbnail_large_url,title&limit=20&sort=recent&page=1'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id)
-
-
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
     headers = {'User-Agent': 'Android'}
@@ -59,13 +55,10 @@ def get_live_url(plugin, item_id, **kwargs):
     return False
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    url = URL_REPLAY % (item_id)
-    return list_videos(plugin, item_id, url)
-
-
 @Route.register
-def list_videos(plugin, item_id, url, **kwargs):
+def list_videos(plugin, item_id, url=None, **kwargs):
+    if not url:
+        url = URL_REPLAY % (item_id)
     headers = {'User-Agent': 'Android'}
     r = urlquick.get(url, headers=headers)
     json_parser = json.loads(r.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/mtv_fr.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/mtv_fr.py
@@ -51,13 +51,6 @@ URL_EMISSION = URL_ROOT + '/emissions/'
 URL_VIDEOS = URL_ROOT + '/dernieres-videos'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
 

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal.py
@@ -86,13 +86,6 @@ LIVE_DAILYMOTION_ID = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return mycanal_root(plugin)
-
-
 @Route.register
 def mycanal_root(plugin, **kwargs):
 
@@ -607,12 +600,8 @@ def get_video_url(plugin,
         return json_parser["detail"]["informations"]["playsets"]["available"][0]["videoURL"]
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     return resolver_proxy.get_stream_dailymotion(
         plugin, LIVE_DAILYMOTION_ID[item_id], False)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1.py
@@ -75,13 +75,6 @@ VIDEO_TYPES = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return mytf1_root(plugin)
-
-
 @Route.register
 def mytf1_root(plugin, **kwargs):
 
@@ -356,12 +349,8 @@ def get_video_url(plugin,
         return item
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
     video_id = 'L_%s' % item_id.upper()
 
     video_format = 'hls'

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/nrj.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/nrj.py
@@ -56,15 +56,8 @@ URL_LIVE_WITH_TOKEN = URL_ROOT + '/compte/live?channel=%s'
 # call this url after get session (url live with token inside this page)
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return nrjplay_root(plugin)
-
-
 @Route.register
-def nrjplay_root(plugin):
+def nrjplay_root(plugin, **kwargs):
 
     # (item_id, label, thumb, fanart)
     channels = [
@@ -203,12 +196,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     # Live TV Not working / find a way to dump html received
 

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/ouatchtv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/ouatchtv.py
@@ -44,13 +44,6 @@ URL_EMISSIONS = URL_ROOT + '/emissions'
 LIVE_DAILYMOTION_ID = {'ouatchtv': 'xuw47s'}
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -115,12 +108,8 @@ def get_video_url(plugin,
                                                  download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     return resolver_proxy.get_stream_dailymotion(plugin,
                                                  LIVE_DAILYMOTION_ID[item_id],

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/publicsenat.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/publicsenat.py
@@ -56,13 +56,6 @@ CATEGORIES = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -147,12 +140,8 @@ def get_video_url(plugin,
                                                  download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_SITE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/rmc.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/rmc.py
@@ -47,13 +47,6 @@ URL_REPLAY = {
 URL_LIVE = URL_ROOT + '/mediaplayer-direct/'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -136,12 +129,8 @@ def get_video_url(plugin,
                                                     download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE % item_id,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/rtl.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/rtl.py
@@ -43,12 +43,8 @@ URL_ROOT = "https://www.rtl.fr"
 URL_LIVE = URL_ROOT + '/direct/videoplayer'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/sportenfrance.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/sportenfrance.py
@@ -40,12 +40,8 @@ import urlquick
 URL_ROOT = "https://www.sportenfrance.com"
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_ROOT, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tebeo.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tebeo.py
@@ -46,13 +46,6 @@ URL_REPLAY = URL_ROOT + '/le-replay'
 URL_STREAM = URL_ROOT + '/player.php?idprogramme=%s'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -137,12 +130,8 @@ def get_video_url(plugin,
     return final_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE % item_id, max_age=-1)
     if 'http' in re.compile(r'source\: \"(.*?)\"').findall(resp.text)[0]:

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/telegrenoble.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/telegrenoble.py
@@ -48,13 +48,6 @@ URL_VIDEOS = URL_ROOT + '/views/htmlFragments/replayDetail_pages.php?page=%s&ele
 # Page, Category_Id
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -125,12 +118,8 @@ def get_video_url(plugin,
                                                  download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/telenantes.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/telenantes.py
@@ -43,12 +43,8 @@ URL_ROOT = "https://www.telenantes.com"
 URL_LIVE = URL_ROOT + '/direct'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tf1thematiques.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tf1thematiques.py
@@ -64,13 +64,6 @@ URL_LICENCE_KEY = 'https://drm-wide.tf1.fr/proxy?id=%s|Content-Type=&User-Agent=
 DESIRED_QUALITY = Script.setting['quality']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tl7.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tl7.py
@@ -48,13 +48,6 @@ URL_REPLAY = URL_ROOT + '/replay.html'
 URL_VIDEOS = URL_ROOT + '/views/htmlFragments/replayDetail_pages.php?page=%s&elementsPerPage=10&idEmission=%s'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -124,12 +117,8 @@ def get_video_url(plugin,
                                                  download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tlc.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tlc.py
@@ -43,12 +43,8 @@ URL_ROOT = "http://www.tlc-cholet.fr"
 URL_LIVE = URL_ROOT + '/le-direct'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tv7bordeaux.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tv7bordeaux.py
@@ -41,12 +41,8 @@ import urlquick
 URL_ROOT = "http://www.tv7.com"
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_ROOT, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tv8montblanc.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tv8montblanc.py
@@ -44,10 +44,6 @@ URL_LIVES = 'https://api.dailymotion.com/user/%s/videos?fields=id,thumbnail_larg
 URL_REPLAY = 'https://api.dailymotion.com/user/%s/videos?fields=description,duration,id,taken_time,thumbnail_large_url,title&limit=20&sort=recent&page=1'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id)
-
-
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
     headers = {'User-Agent': 'Android'}
@@ -59,13 +55,10 @@ def get_live_url(plugin, item_id, **kwargs):
     return False
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    url = URL_REPLAY % (item_id)
-    return list_videos(plugin, item_id, url)
-
-
 @Route.register
-def list_videos(plugin, item_id, url, **kwargs):
+def list_videos(plugin, item_id, url=None, **kwargs):
+    if not url:
+        url = URL_REPLAY % (item_id)
     headers = {'User-Agent': 'Android'}
     r = urlquick.get(url, headers=headers)
     json_parser = json.loads(r.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvpifr.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvpifr.py
@@ -41,13 +41,6 @@ import urlquick
 URL_ROOT = 'http://www.tvpi.fr'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -132,12 +125,8 @@ def get_video_url(plugin,
     return final_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT)
     return re.compile(r'file\'\: \'(.*?)\'').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvr.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvr.py
@@ -42,12 +42,8 @@ URL_ROOT = "https://www.tvr.bzh"
 URL_LIVE = URL_ROOT + '/interactiv_video_player/direct?ap=1'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, verify=False, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvt.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvt.py
@@ -41,12 +41,8 @@ import urlquick
 URL_ROOT = "http://www.tvtours.fr"
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_ROOT, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvvendee.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/tvvendee.py
@@ -43,12 +43,8 @@ URL_ROOT = "http://www.tvvendee.fr"
 URL_LIVE = URL_ROOT + '/le-direct'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/via.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/via.py
@@ -58,13 +58,6 @@ URL_STREAM_INFOMANIAK = 'https://livevideo.infomaniak.com/player_config/%s.json'
 # player_id
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -128,12 +121,8 @@ def get_video_url(plugin,
     return final_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if item_id == 'viavosges':
 

--- a/plugin.video.catchuptvandmore/resources/lib/channels/fr/weo.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/fr/weo.py
@@ -43,12 +43,8 @@ URL_ROOT = "https://www.weo.fr"
 URL_LIVE = URL_ROOT + "/direct/"
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(
         URL_LIVE, headers={"User-Agent": web_utils.get_random_ua()}, max_age=-1)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/it/la7.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/it/la7.py
@@ -54,13 +54,6 @@ URL_LIVE = URL_ROOT + '/dirette-tv'
 URL_LICENCE_KEY = 'https://la7.prod.conax.cloud/widevine/license|Content-Type=&User-Agent=Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3041.0 Safari/537.36&preauthorization=%s|R{SSM}|'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_days(plugin, item_id)
-
-
 @Route.register
 def list_days(plugin, item_id, **kwargs):
     """
@@ -139,12 +132,8 @@ def get_video_url(plugin,
             'csmil', 'urlset')
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if get_kodi_version() < 18:
         xbmcgui.Dialog().ok('Info', plugin.localize(30602))

--- a/plugin.video.catchuptvandmore/resources/lib/channels/it/paramountchannel_it.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/it/paramountchannel_it.py
@@ -41,12 +41,8 @@ import urlquick
 URL_LIVE = 'https://www.paramountchannel.it/tv/diretta'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, max_age=-1)
     video_uri = re.compile(r'uri\"\:\"(.*?)\"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay.py
@@ -49,13 +49,6 @@ URL_LIVE = URL_ROOT + '/dirette/%s'
 URL_REPLAYS = URL_ROOT + '/dl/RaiTV/RaiPlayMobile/Prod/Config/programmiAZ-elenco.json'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_letters(plugin, item_id)
-
-
 @Route.register
 def list_letters(plugin, item_id, **kwargs):
     """
@@ -189,12 +182,8 @@ def get_video_url(plugin,
     return item
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE % item_id, max_age=-1)
     return re.compile(r'\"content_url\"\:\"(.*?)\"').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/jp/japanetshoppingdx.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/jp/japanetshoppingdx.py
@@ -43,12 +43,8 @@ URL_ROOT = 'http://www.japanet.co.jp'
 URL_LIVE = URL_ROOT + '/shopping/movie/movie_player_dx.html'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/jp/nhklifestyle.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/jp/nhklifestyle.py
@@ -47,13 +47,6 @@ URL_API_STREAM_NHK = 'http://movie-s.nhk.or.jp/ws/ws_program/api/%s/apiv/5/mode/
 # Api_Key, VideoId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/jp/nhknews.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/jp/nhknews.py
@@ -62,13 +62,6 @@ CORRECT_MONTH = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/jp/ntvnews24.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/jp/ntvnews24.py
@@ -43,12 +43,8 @@ URL_ROOT = 'http://www.news24.jp'
 URL_LIVE = URL_ROOT + '/livestream/'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/jp/tbsnews.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/jp/tbsnews.py
@@ -45,13 +45,6 @@ URL_STREAM = 'https://flvstream.tbs.co.jp/flvfiles/_definst_/newsi/digest/%s_1m.
 NEWS_CONTENT = ['nb', '23', 'nst', 'jnn']
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/jp/tver.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/jp/tver.py
@@ -54,13 +54,6 @@ URL_BRIGHTCOVE_VIDEO_JSON = 'https://edge.api.brightcove.com/'\
 # AccountId, VideoId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/jp/weathernewsjp.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/jp/weathernewsjp.py
@@ -43,12 +43,8 @@ URL_ROOT = 'http://weathernews.jp'
 URL_LIVE_JSON = URL_ROOT + '/s/live/json/youtube.json'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_JSON,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/nl/at5.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/nl/at5.py
@@ -48,13 +48,6 @@ URL_VIDEOS = 'https://at5news.vinsontv.com/api/news?source=web&slug=%s&page=%s'
 # slug, page
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -157,12 +150,8 @@ def get_video_yt_url(plugin,
     return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE,
                         headers={'User-Agent': web_utils.get_random_ua()},

--- a/plugin.video.catchuptvandmore/resources/lib/channels/nl/npo.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/nl/npo.py
@@ -66,13 +66,6 @@ URL_IMAGE = 'https://images.poms.omroep.nl/image/s1280/c1280x720/%s.jpg'
 # ImageId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -340,12 +333,8 @@ def get_video_url(plugin,
     return item
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if get_kodi_version() < 18:
         xbmcgui.Dialog().ok('Info', plugin.localize(30602))

--- a/plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp.py
@@ -63,12 +63,8 @@ LIVE_TVP3_REGIONS = {
 }
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
     final_language = kwargs.get('language', Script.setting['tvp3.language'])
 
     resp = urlquick.get(URL_LIVE,

--- a/plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo.py
@@ -29,7 +29,7 @@ from codequick import Route, Resolver, Listitem, utils, Script
 
 
 @Resolver.register
-def live_entry(plugin, item_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
     m3u8 = {
         'slo1': 'https://31-rtvslo-tv-slo1-int.cdn.eurovisioncdn.net/playlist.m3u8',
         'slo2': 'https://21-rtvslo-tv-slo2-int.cdn.eurovisioncdn.net/playlist.m3u8',

--- a/plugin.video.catchuptvandmore/resources/lib/channels/tn/nessma.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/tn/nessma.py
@@ -49,13 +49,6 @@ URL_REPLAY = URL_ROOT + '/ar/replays'
 URL_VIDEOS = URL_ROOT + '/ar/videos'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -185,12 +178,8 @@ def get_video_url(plugin,
     return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/tn/watania.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/tn/watania.py
@@ -43,12 +43,8 @@ URL_ROOT = 'http://www.%s.tn'
 # channel_name
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT % item_id)
     root = resp.parse()

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/blaze.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/blaze.py
@@ -53,13 +53,6 @@ URL_REPLAY = URL_ROOT + '/replay/'
 URL_REPLAY_JSON = 'https://vod.blaze.tv/stream-vod.php?key=%s&platform=chrome'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -132,12 +125,8 @@ def get_video_url(plugin,
     return json_parser2["Streams"]["Adaptive"]
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     live_id = re.compile(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus.py
@@ -42,12 +42,8 @@ URL_ROOT = 'https://www.boxplus.com'
 URL_LIVE_ID = URL_ROOT + '/live-tv-guide/?channel=%s'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
     """Get video URL and start video player"""
     resp = urlquick.get(URL_LIVE_ID % item_id)
     return re.compile('src: \'(.*?)\'').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/bristoltv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/bristoltv.py
@@ -41,13 +41,6 @@ import urlquick
 URL_ROOT = 'https://www.bristollocal.tv'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -143,12 +136,8 @@ def get_video_url(plugin,
     return resolver_proxy.get_stream_dailymotion(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
     """Get video URL and start video player"""
 
     resp = urlquick.get(URL_ROOT,

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/my5.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/my5.py
@@ -59,13 +59,6 @@ URL_IMAGES = URL_ROOT + "/isl/api/v1/dataservice/ResizeImage/$value?ImageId='%s'
 # ImageId, EntityId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/questod.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/questod.py
@@ -75,13 +75,6 @@ CATEGORIES_MODE = {
 CATEGORIES_MODE_AZ = {'A-Z': '-az'}
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -284,12 +277,8 @@ def get_video_url(plugin,
         return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if get_kodi_version() < 18:
         xbmcgui.Dialog().ok('Info', plugin.localize(30602))

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/sky.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/sky.py
@@ -67,13 +67,6 @@ URL_OOYALA_VOD = 'https://player.ooyala.com/sas/player_api/v2/authorization/' \
 URL_PCODE_EMBED_TOKEN = 'http://www.skysports.com/watch/video/auth/v4/23'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
 
@@ -200,12 +193,8 @@ def get_video_url(plugin,
     return False
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_SKYNEWS)
     live_id = re.compile(r'www.youtube.com/embed/(.*?)\?').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/stv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/stv.py
@@ -138,12 +138,8 @@ def get_video_url(plugin,
                                                     download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if item_id == 'stv_plusone':
         item_id = 'stv-plus-1'

--- a/plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay.py
@@ -98,13 +98,6 @@ URL_LOGIN_MODAL = 'https://uktvplay.uktv.co.uk/account/'
 URL_COMPTE_LOGIN = 'https://live.mppglobal.com/api/accounts/authenticate/'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -333,12 +326,8 @@ def get_video_url(plugin, item_id, data_video_id, **kwargs):
     return item
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if get_kodi_version() < 18:
         xbmcgui.Dialog().ok('Info', plugin.localize(30602))

--- a/plugin.video.catchuptvandmore/resources/lib/channels/us/abcnews.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/us/abcnews.py
@@ -47,13 +47,6 @@ URL_REPLAY_STREAM = URL_ROOT + '/video/itemfeed?id=%s'
 # videoId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -132,12 +125,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_STREAM)
     json_parser = json.loads(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/us/cbsnews.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/us/cbsnews.py
@@ -43,12 +43,8 @@ URL_ROOT = 'https://www.cbsnews.com'
 URL_LIVE = URL_ROOT + '/live'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     for line in resp.text.split('\n'):

--- a/plugin.video.catchuptvandmore/resources/lib/channels/us/nycmedia.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/us/nycmedia.py
@@ -53,13 +53,6 @@ URL_STREAM = URL_API + '/embedplayer.php?id=%s'
 # videoId
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/us/pbskids.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/us/pbskids.py
@@ -43,12 +43,8 @@ URL_ROOT = 'http://pbskids.org'
 URL_LIVE = URL_ROOT + '/api/video/v1/livestream?station=KIDS'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     json_parser = json.loads(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/us/tbd.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/us/tbd.py
@@ -44,13 +44,6 @@ URL_REPLAY = URL_ROOT + '/shows'
 URL_LIVE = URL_ROOT + '/live'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_programs(plugin, item_id)
-
-
 @Route.register
 def list_programs(plugin, item_id, **kwargs):
     """
@@ -128,12 +121,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     return re.compile(r'file\': "(.*?)"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/africa24.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/africa24.py
@@ -41,13 +41,6 @@ import urlquick
 URL_ROOT = "https://www.africa24tv.com"
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -193,12 +186,8 @@ def get_video_url(plugin,
     return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT)
     live_id = re.compile(r"youtube\.com\/embed\/(.*?)\"").findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/afriquemedia.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/afriquemedia.py
@@ -46,13 +46,6 @@ URL_REPLAY = URL_ROOT + '/replay?jut1=%s'
 # page
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -106,12 +99,8 @@ def get_video_url(plugin,
     return resolver_proxy.get_stream_youtube(plugin, video_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     live_id = re.compile(r'dailymotion.com/embed/video/(.*?)[\?\"]').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/arirang.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/arirang.py
@@ -48,13 +48,6 @@ URL_STREAM = 'http://amdlive.ctnd.com.edgesuite.net/' \
              'arirang_1ch/smil:arirang_1ch.smil/playlist.m3u8'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -147,10 +140,6 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
     return URL_STREAM

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/arte.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/arte.py
@@ -77,13 +77,6 @@ CORRECT_MONTH = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -541,10 +534,6 @@ def get_video_url(plugin,
         return download.download_video(url_selected)
 
     return url_selected
-
-
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
 
 
 @Resolver.register

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/beinsports.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/beinsports.py
@@ -51,13 +51,6 @@ URL_VIDEOS = URL_API_ROOT + '/contents?itemsPerPage=30&type=3&site=%s&page=%s&ta
 # siteId, page
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_sites(plugin, item_id)
-
-
 @Route.register
 def list_sites(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/bvn.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/bvn.py
@@ -54,13 +54,6 @@ URL_SUBTITLE = 'https://rs.poms.omroep.nl/v1/api/subtitles/%s'
 # Id Video
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_days(plugin, item_id)
-
-
 @Route.register
 def list_days(plugin, item_id, **kwargs):
     """
@@ -174,12 +167,8 @@ def get_video_url(plugin,
     return item
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     if get_kodi_version() < 18:
         xbmcgui.Dialog().ok('Info', plugin.localize(30602))
@@ -220,7 +209,7 @@ def get_live_url(plugin, item_id, video_id, **kwargs):
     item.art.update(get_selected_item_art())
     item.info.update(get_selected_item_info())
     if plugin.setting.get_boolean('active_subtitle'):
-        item.subtitles.append(URL_SUBTITLE % video_id)
+        item.subtitles.append(URL_SUBTITLE % item_id)
     item.property['inputstreamaddon'] = 'inputstream.adaptive'
     item.property['inputstream.adaptive.manifest_type'] = 'mpd'
     item.property['inputstream.adaptive.license_type'] = 'com.widevine.alpha'

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn.py
@@ -40,10 +40,6 @@ URL_LIVE_CGTN = 'https://news.cgtn.com/resource/live/%s/cgtn-%s.m3u8'
 # Channel (FR|ES|AR|EN|RU|DO(documentary))
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
-
-
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
     final_language = kwargs.get('language', Script.setting['cgtn.language'])

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/channelnewsasia.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/channelnewsasia.py
@@ -61,13 +61,6 @@ URL_SHOWS_DATAS = URL_ROOT + '/news/video-on-demand'
 URL_SHOWS = URL_ROOT + '/dynamiclist?contextId=%s&pageIndex=%s'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -246,12 +239,8 @@ def get_video_url(plugin,
     return False
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE_ID)
     list_stream_id = re.compile('video-asset-id="(.*?)"').findall(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/dw.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/dw.py
@@ -40,10 +40,6 @@ import urlquick
 URL_ROOT = 'http://www.dw.com'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
-
-
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
     final_language = kwargs.get('language', Script.setting['dw.language'])

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews.py
@@ -42,10 +42,6 @@ URL_LIVE_API = 'http://%s.euronews.com/api/watchlive.json'
 DESIRED_LANGUAGE = Script.setting['euronews.language']
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
-
-
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
     final_language = kwargs.get('language', Script.setting['euronews.language'])

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/france24.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/france24.py
@@ -41,13 +41,6 @@ TOKEN_APP = '66b85dad-3ad5-40f3-ab32-2305fc2357ea'
 URL_API = utils.urljoin_partial('http://apis.france24.com')
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return root(plugin, item_id)
-
-
 def root(plugin, item_id, **kwargs):
     # http://apis.france24.com/products/get_product/78dcf358-9333-4fb2-a035-7b91e9705b13?token_application=66b85dad-3ad5-40f3-ab32-2305fc2357ea
     root_json_url = 'products/get_product/78dcf358-9333-4fb2-a035-7b91e9705b13'
@@ -336,7 +329,8 @@ def get_video_url(plugin,
     return resolver_proxy.get_stream_youtube(plugin, youtube_id, download_mode)
 
 
-def live_entry(plugin, item_id, **kwargs):
+@Resolver.register
+def get_live_url(plugin, item_id, **kwargs):
     final_language = kwargs.get('language', LANG)
 
     root_json_url = 'products/get_product/78dcf358-9333-4fb2-a035-7b91e9705b13'

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/icirdi.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/icirdi.py
@@ -41,12 +41,8 @@ URL_API = 'https://api.radio-canada.ca/validationMedia/v1/Validation.html'
 URL_LIVE = URL_API + '?connectionType=broadband&output=json&multibitrate=true&deviceType=ipad&appCode=medianetlive&idMedia=rdi'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     json_parser = json.loads(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/icitelevision.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/icitelevision.py
@@ -41,12 +41,8 @@ URL_ROOT = 'https://icitelevision.ca'
 URL_LIVE = URL_ROOT + '/live-video/'
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     return re.compile('source src=\"(.*?)\"').findall(resp.text)[0]

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/nhkworld.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/nhkworld.py
@@ -66,13 +66,6 @@ def get_api_key(item_id):
     return list_apikey[0]
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -149,10 +142,6 @@ def get_video_url(plugin,
     if download_mode:
         return download.download_video(final_video_url)
     return final_video_url
-
-
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
 
 
 @Resolver.register

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc.py
@@ -51,10 +51,6 @@ URL_STREAM_LIMELIGHT = 'http://production-ps.lvp.llnw.net/r/PlaylistService/medi
 DESIRED_LANGUAGE = Script.setting['qvc.language']
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
-
-
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
     final_language = kwargs.get('language', Script.setting['qvc.language'])

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/rt.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/rt.py
@@ -63,13 +63,6 @@ CATEGORIES_VIDEOS_FR = {
 CATEGORIES_VIDEOS_EN = {URL_ROOT_EN + '/shows/': 'Shows'}
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -354,10 +347,6 @@ def get_video_url(plugin,
             return download.download_video(final_url)
 
         return final_url
-
-
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, **kwargs)
 
 
 @Resolver.register

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/tivi5monde.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/tivi5monde.py
@@ -54,13 +54,6 @@ CATEGORIES_VIDEOS_TIVI5MONDE = {
 }
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -200,12 +193,8 @@ def get_video_url(plugin,
     return stream_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     live_id = ''
     for channel_name, live_id_value in list(LIST_LIVE_TV5MONDE.items()):

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5monde.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5monde.py
@@ -46,13 +46,6 @@ URL_TV5MONDE_ROOT = 'https://revoir.tv5monde.com'
 LIST_LIVE_TV5MONDE = {'tv5mondefbs': 'fbs', 'tv5mondeinfo': 'infoplus'}
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """
@@ -193,12 +186,8 @@ def get_video_url(plugin,
     return final_video_url
 
 
-def live_entry(plugin, item_id, **kwargs):
-    return get_live_url(plugin, item_id, item_id.upper())
-
-
 @Resolver.register
-def get_live_url(plugin, item_id, video_id, **kwargs):
+def get_live_url(plugin, item_id, **kwargs):
 
     live_id = ''
     for channel_name, live_id_value in list(LIST_LIVE_TV5MONDE.items()):

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5mondeafrique.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5mondeafrique.py
@@ -42,13 +42,6 @@ import urlquick
 URL_TV5MAF_ROOT = 'https://afrique.tv5monde.com'
 
 
-def replay_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after replay_bridge
-    """
-    return list_categories(plugin, item_id)
-
-
 @Route.register
 def list_categories(plugin, item_id, **kwargs):
     """

--- a/plugin.video.catchuptvandmore/resources/lib/main.py
+++ b/plugin.video.catchuptvandmore/resources/lib/main.py
@@ -107,20 +107,21 @@ def generic_menu(plugin, item_id=None, **kwargs):
                 item.art["fanart"] = get_item_media_path(
                     item_infos['fanart'])
 
-            # Set item params
-            # If this item requires a module to work, get
-            # the module path to be loaded
-            if 'module' in item_infos:
-                item.params['item_module'] = item_infos['module']
-
+            # Set item additional params
             if 'xmltv_id' in item_infos:
                 item.params['xmltv_id'] = item_infos['xmltv_id']
 
             item.params['item_id'] = item_id
 
-            # Get cllback function of this item
-            item_callback = eval(item_infos['callback'])
-            item.set_callback(item_callback)
+            # Set callback function for this item
+            if 'route' in item_infos:
+                item.set_callback((Route.ref(item_infos['route'])))
+            elif 'resolver' in item_infos:
+                item.set_callback((Resolver.ref(item_infos['resolver'])))
+            else:
+                # This case should not happen
+                # Ignore this item to prevent any error for this menu
+                continue
 
             # Add needed context menus to this item
             add_context_menus_to_item(item,
@@ -128,7 +129,7 @@ def generic_menu(plugin, item_id=None, **kwargs):
                                       index,
                                       menu_id,
                                       len(menu),
-                                      is_playable=(item_infos['callback'] == 'live_bridge'),
+                                      is_playable='resolver' in item_infos,
                                       item_infos=item_infos)
 
             yield item
@@ -206,73 +207,6 @@ def tv_guide_menu(plugin, item_id, **kwargs):
                 item.art["clearlogo"] = item.art["thumb"]
                 item.art["thumb"] = guide_infos['icon']
         yield item
-
-
-@Route.register
-def replay_bridge(plugin, item_id, item_module, **kwargs):
-    """Bridge between main.py file and each channel modules files
-
-    Args:
-        plugin (codequick.script.Script)
-        item_id (str): Catch-up TV channel menu to build (e.g. tf1)
-        item_module (str): Channel module (e.g. resources.lib.channels.fr.mytf1)
-    Returns:
-        Iterator[codequick.listing.Listitem]: Kodi 'item_id' menu
-    """
-
-    module = importlib.import_module(item_module)
-    return module.replay_entry(plugin, item_id)
-
-
-@Route.register
-def website_bridge(plugin, item_id, item_module, **kwargs):
-    """Bridge between main.py file and each website modules files
-
-    Args:
-        plugin (codequick.script.Script)
-        item_id (str): Website menu to build (e.g. allocine)
-        item_module (str): Channel module (e.g. resources.lib.websites.allocine)
-    Returns:
-        Iterator[codequick.listing.Listitem]: Kodi 'item_id' menu
-    """
-
-    module = importlib.import_module(item_module)
-    return module.website_entry(plugin, item_id)
-
-
-@Route.register
-def multi_live_bridge(plugin, item_id, item_module, **kwargs):
-    """Bridge between main.py file and each channel modules files
-
-    Args:
-        plugin (codequick.script.Script)
-        item_id (str): Multi live TV channel menu to build (e.g. auvio)
-        item_module (str): Channel module (e.g. resources.lib.channels.be.rtbf)
-    Returns:
-        Iterator[codequick.listing.Listitem]: Kodi 'item_id' menu
-    """
-
-    # Let's go to the module file ...
-    module = importlib.import_module(item_module)
-    return module.multi_live_entry(plugin, item_id)
-
-
-@Resolver.register
-def live_bridge(plugin, item_id, item_module, **kwargs):
-    """Bridge between main.py file and each channel modules files
-
-    Args:
-        plugin (codequick.script.Script)
-        item_id (str): Live TV channel menu to build (e.g. tf1)
-        item_module (str): Channel module (e.g. resources.lib.channels.fr.mytf1)
-        **kwargs: Arbitrary keyword arguments
-    Returns:
-        Iterator[codequick.listing.Listitem]: Kodi 'item_id' menu
-    """
-
-    # Let's go to the module file ...
-    module = importlib.import_module(item_module)
-    return module.live_entry(plugin, item_id, **kwargs)
 
 
 @Route.register

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/be_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/be_live.py
@@ -30,263 +30,237 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'rtl_tvi': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtlplaybe:get_live_url',
         'label': 'RTL-TVI',
         'thumb': 'channels/be/rtltvi.png',
         'fanart': 'channels/be/rtltvi_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'xmltv_id': 'C168.api.telerama.fr',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 2
     },
     'plug_rtl': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtlplaybe:get_live_url',
         'label': 'PLUG RTL',
         'thumb': 'channels/be/plugrtl.png',
         'fanart': 'channels/be/plugrtl_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'xmltv_id': 'C377.api.telerama.fr',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 3
     },
     'club_rtl': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtlplaybe:get_live_url',
         'label': 'CLUB RTL',
         'thumb': 'channels/be/clubrtl.png',
         'fanart': 'channels/be/clubrtl_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'xmltv_id': 'C50.api.telerama.fr',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 4
     },
     'telemb': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/telemb:get_live_url',
         'label': 'Télé MB',
         'thumb': 'channels/be/telemb.png',
         'fanart': 'channels/be/telemb_fanart.jpg',
-        'module': 'resources.lib.channels.be.telemb',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 6
     },
     'rtc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtc:get_live_url',
         'label': 'RTC Télé Liège',
         'thumb': 'channels/be/rtc.png',
         'fanart': 'channels/be/rtc_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtc',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 7
     },
     'auvio': {
-        'callback': 'multi_live_bridge',
+        'route': '/resources/lib/channels/be/rtbf:list_lives',
         'label': 'RTBF Auvio',
         'thumb': 'channels/be/auvio.png',
         'fanart': 'channels/be/auvio_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
         'enabled': True,
         'order': 8
     },
     'tvlux': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/tvlux:get_live_url',
         'label': 'TV Lux',
         'thumb': 'channels/be/tvlux.png',
         'fanart': 'channels/be/tvlux_fanart.jpg',
-        'module': 'resources.lib.channels.be.tvlux',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 9
     },
     'rtl_info': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtlplaybe:get_live_url',
         'label': 'RTL INFO',
         'thumb': 'channels/be/rtlinfo.png',
         'fanart': 'channels/be/rtlinfo_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 10
     },
     'bel_rtl': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtlplaybe:get_live_url',
         'label': 'BEL RTL',
         'thumb': 'channels/be/belrtl.png',
         'fanart': 'channels/be/belrtl_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 11
     },
     'contact': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtlplaybe:get_live_url',
         'label': 'Contact',
         'thumb': 'channels/be/contact.png',
         'fanart': 'channels/be/contact_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr Radio',
         'enabled': True,
         'order': 12
     },
     'bx1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/bx1:get_live_url',
         'label': 'BX1',
         'thumb': 'channels/be/bx1.png',
         'fanart': 'channels/be/bx1_fanart.jpg',
-        'module': 'resources.lib.channels.be.bx1',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 13
     },
     'een': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/vrt:get_live_url',
         'label': 'Één',
         'thumb': 'channels/be/een.png',
         'fanart': 'channels/be/een_fanart.jpg',
-        'module': 'resources.lib.channels.be.vrt',
         'xmltv_id': 'C23.api.telerama.fr',
         'm3u_group': 'België nl',
         'enabled': True,
         'order': 14
     },
     'canvas': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/vrt:get_live_url',
         'label': 'Canvas',
         'thumb': 'channels/be/canvas.png',
         'fanart': 'channels/be/canvas_fanart.jpg',
-        'module': 'resources.lib.channels.be.vrt',
         'm3u_group': 'België nl',
         'enabled': True,
         'order': 15
     },
     'ketnet': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/vrt:get_live_url',
         'label': 'Ketnet',
         'thumb': 'channels/be/ketnet.png',
         'fanart': 'channels/be/ketnet_fanart.jpg',
-        'module': 'resources.lib.channels.be.vrt',
         'xmltv_id': 'C1280.api.telerama.fr',
         'm3u_group': 'België nl',
         'enabled': True,
         'order': 16
     },
     'nrjhitstvbe': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/nrjhitstvbe:get_live_url',
         'label': 'NRJ Hits TV',
         'thumb': 'channels/be/nrjhitstvbe.png',
         'fanart': 'channels/be/nrjhitstvbe_fanart.jpg',
-        'module': 'resources.lib.channels.be.nrjhitstvbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 17
     },
     'rtl_sport': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtlplaybe:get_live_url',
         'label': 'RTL Sport',
         'thumb': 'channels/be/rtlsport.png',
         'fanart': 'channels/be/rtlsport_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 18
     },
     'tvcom': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/tvcom:get_live_url',
         'label': 'TV Com',
         'thumb': 'channels/be/tvcom.png',
         'fanart': 'channels/be/tvcom_fanart.jpg',
-        'module': 'resources.lib.channels.be.tvcom',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 19
     },
     'canalc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/canalc:get_live_url',
         'label': 'Canal C',
         'thumb': 'channels/be/canalc.png',
         'fanart': 'channels/be/canalc_fanart.jpg',
-        'module': 'resources.lib.channels.be.canalc',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 20
     },
     'abxplore': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/abbe:get_live_url',
         'label': 'ABXPLORE',
         'thumb': 'channels/be/abxplore.png',
         'fanart': 'channels/be/abxplore_fanart.jpg',
-        'module': 'resources.lib.channels.be.abbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 21
     },
     'ab3': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/abbe:get_live_url',
         'label': 'AB3',
         'thumb': 'channels/be/ab3.png',
         'fanart': 'channels/be/ab3_fanart.jpg',
-        'module': 'resources.lib.channels.be.abbe',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 22
     },
     'ln24': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/ln24:get_live_url',
         'label': 'LN24',
         'thumb': 'channels/be/ln24.png',
         'fanart': 'channels/be/ln24_fanart.jpg',
-        'module': 'resources.lib.channels.be.ln24',
         'm3u_group': 'Belgique fr',
         'enabled': True,
         'order': 23
     },
     'laune': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtbf:set_live_url',
         'label': 'La Une',
         'thumb': 'channels/be/laune.png',
         'fanart': 'channels/be/laune_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
         'xmltv_id': 'C164.api.telerama.fr',
         'enabled': True,
         'order': 24
     },
     'ladeux': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtbf:set_live_url',
         'label': 'La Deux',
         'thumb': 'channels/be/ladeux.png',
         'fanart': 'channels/be/ladeux_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
         'xmltv_id': 'C187.api.telerama.fr',
         'enabled': True,
         'order': 25
     },
     'latrois': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/rtbf:set_live_url',
         'label': 'La Trois',
         'thumb': 'channels/be/latrois.png',
         'fanart': 'channels/be/latrois_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
         'xmltv_id': 'C892.api.telerama.fr',
         'enabled': True,
         'order': 26
     },
     'actv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/be/actv:get_live_url',
         'label': 'Antenne Centre TV',
         'thumb': 'channels/be/actv.png',
         'fanart': 'channels/be/actv_fanart.jpg',
-        'module': 'resources.lib.channels.be.actv',
         'enabled': True,
         'order': 27
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/be_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/be_replay.py
@@ -30,109 +30,97 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'brf': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/brf:list_categories',
         'label': 'BRF Mediathek',
         'thumb': 'channels/be/brf.png',
         'fanart': 'channels/be/brf_fanart.jpg',
-        'module': 'resources.lib.channels.be.brf',
         'enabled': True,
         'order': 1
     },
     'rtlplay': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/rtlplaybe:rtlplay_root',
         'label': 'RTLplay',
         'thumb': 'channels/be/rtlplay.png',
         'fanart': 'channels/be/rtlplay_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtlplaybe',
         'enabled': True,
         'order': 2
     },
     'vrt': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/vrt:list_root',
         'label': 'VRT NU',
         'thumb': 'channels/be/vrt.png',
         'fanart': 'channels/be/vrt_fanart.jpg',
-        'module': 'resources.lib.channels.be.vrt',
         'enabled': True,
         'order': 5
     },
     'telemb': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/telemb:list_programs',
         'label': 'Télé MB',
         'thumb': 'channels/be/telemb.png',
         'fanart': 'channels/be/telemb_fanart.jpg',
-        'module': 'resources.lib.channels.be.telemb',
         'enabled': True,
         'order': 6
     },
     'rtc': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/rtc:list_categories',
         'label': 'RTC Télé Liège',
         'thumb': 'channels/be/rtc.png',
         'fanart': 'channels/be/rtc_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtc',
         'enabled': True,
         'order': 7
     },
     'auvio': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/rtbf:list_categories',
         'label': 'RTBF Auvio',
         'thumb': 'channels/be/auvio.png',
         'fanart': 'channels/be/auvio_fanart.jpg',
-        'module': 'resources.lib.channels.be.rtbf',
         'enabled': True,
         'order': 8
     },
     'tvlux': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/tvlux:list_categories',
         'label': 'TV Lux',
         'thumb': 'channels/be/tvlux.png',
         'fanart': 'channels/be/tvlux_fanart.jpg',
-        'module': 'resources.lib.channels.be.tvlux',
         'enabled': True,
         'order': 9
     },
     'bx1': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/bx1:list_programs',
         'label': 'BX1',
         'thumb': 'channels/be/bx1.png',
         'fanart': 'channels/be/bx1_fanart.jpg',
-        'module': 'resources.lib.channels.be.bx1',
         'enabled': True,
         'order': 13
     },
     'nrjhitstvbe': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/nrjhitstvbe:list_videos',
         'label': 'NRJ Hits TV',
         'thumb': 'channels/be/nrjhitstvbe.png',
         'fanart': 'channels/be/nrjhitstvbe_fanart.jpg',
-        'module': 'resources.lib.channels.be.nrjhitstvbe',
         'enabled': True,
         'order': 17
     },
     'tvcom': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/tvcom:list_categories',
         'label': 'TV Com',
         'thumb': 'channels/be/tvcom.png',
         'fanart': 'channels/be/tvcom_fanart.jpg',
-        'module': 'resources.lib.channels.be.tvcom',
         'enabled': True,
         'order': 19
     },
     'canalc': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/be/canalc:list_programs',
         'label': 'Canal C',
         'thumb': 'channels/be/canalc.png',
         'fanart': 'channels/be/canalc_fanart.jpg',
-        'module': 'resources.lib.channels.be.canalc',
         'enabled': True,
         'order': 20
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/ca_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/ca_live.py
@@ -30,37 +30,33 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'telequebec': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/telequebec:get_live_url',
         'label': 'Télé-Québec',
         'thumb': 'channels/ca/telequebec.png',
         'fanart': 'channels/ca/telequebec_fanart.jpg',
-        'module': 'resources.lib.channels.ca.telequebec',
         'enabled': True,
         'order': 4
     },
     'tva': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/tva:get_live_url',
         'label': 'TVA',
         'thumb': 'channels/ca/tva.png',
         'fanart': 'channels/ca/tva_fanart.jpg',
-        'module': 'resources.lib.channels.ca.tva',
         'enabled': True,
         'order': 5
     },
     'icitele': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/icitele:get_live_url',
         'label': 'ICI Télé (' + utils.ensure_unicode(Script.setting['icitele.language']) + ')',
         'thumb': 'channels/ca/icitele.png',
         'fanart': 'channels/ca/icitele_fanart.jpg',
-        'module': 'resources.lib.channels.ca.icitele',
         'available_languages': [
             'Vancouver', 'Regina', 'Toronto', 'Edmonton', 'Rimouski',
             'Québec', 'Winnipeg', 'Moncton', 'Ottawa',
@@ -70,38 +66,34 @@ menu = {
         'order': 6
     },
     'ntvca': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/ntvca:get_live_url',
         'label': 'NTV',
         'thumb': 'channels/ca/ntvca.png',
         'fanart': 'channels/ca/ntvca_fanart.jpg',
-        'module': 'resources.lib.channels.ca.ntvca',
         'enabled': True,
         'order': 7
     },
     'telemag': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/telemag:get_live_url',
         'label': 'Télé-Mag',
         'thumb': 'channels/ca/telemag.png',
         'fanart': 'channels/ca/telemag_fanart.jpg',
-        'module': 'resources.lib.channels.ca.telemag',
         'enabled': True,
         'order': 9
     },
     'vtele': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/noovo:get_live_url',
         'label': 'V Télé',
         'thumb': 'channels/ca/vtele.png',
         'fanart': 'channels/ca/vtele_fanart.jpg',
-        'module': 'resources.lib.channels.ca.noovo',
         'enabled': True,
         'order': 10
     },
     'cbc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/cbc:get_live_url',
         'label': 'CBC (' + utils.ensure_unicode(Script.setting['cbc.language']) + ')',
         'thumb': 'channels/ca/cbc.png',
         'fanart': 'channels/ca/cbc_fanart.jpg',
-        'module': 'resources.lib.channels.ca.cbc',
         'available_languages': [
             'Ottawa', 'Montreal', 'Charlottetown', 'Fredericton',
             'Halifax', 'Windsor', 'Yellowknife', 'Winnipeg',
@@ -112,20 +104,18 @@ menu = {
         'order': 11
     },
     'lcn': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/tva:get_live_url',
         'label': 'LCN',
         'thumb': 'channels/ca/lcn.png',
         'fanart': 'channels/ca/lcn_fanart.jpg',
-        'module': 'resources.lib.channels.ca.tva',
         'enabled': False,
         'order': 12
     },
     'yoopa': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ca/tva:get_live_url',
         'label': 'Yoopa',
         'thumb': 'channels/ca/yoopa.png',
         'fanart': 'channels/ca/yoopa_fanart.jpg',
-        'module': 'resources.lib.channels.ca.tva',
         'enabled': False,
         'order': 13
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/ca_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/ca_replay.py
@@ -30,73 +30,65 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'tv5unis': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ca/tv5unis:list_categories',
         'label': 'TV5 Unis',
         'thumb': 'channels/ca/tv5unis.png',
         'fanart': 'channels/ca/tv5unis_fanart.jpg',
-        'module': 'resources.lib.channels.ca.tv5unis',
         'enabled': True,
         'order': 1
     },
     'telequebec': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ca/telequebec:list_programs',
         'label': 'Télé-Québec',
         'thumb': 'channels/ca/telequebec.png',
         'fanart': 'channels/ca/telequebec_fanart.jpg',
-        'module': 'resources.lib.channels.ca.telequebec',
         'enabled': True,
         'order': 4
     },
     'tva': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ca/tva:list_categories',
         'label': 'TVA',
         'thumb': 'channels/ca/tva.png',
         'fanart': 'channels/ca/tva_fanart.jpg',
-        'module': 'resources.lib.channels.ca.tva',
         'enabled': True,
         'order': 5
     },
     'icitele': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ca/icitele:list_programs',
         'label': 'ICI Télé (' + utils.ensure_unicode(Script.setting['icitele.language']) + ')',
         'thumb': 'channels/ca/icitele.png',
         'fanart': 'channels/ca/icitele_fanart.jpg',
-        'module': 'resources.lib.channels.ca.icitele',
         'enabled': True,
         'order': 6
     },
     'icitoutv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ca/icitoutv:list_categories',
         'label': 'ICI Tou.tv',
         'thumb': 'channels/ca/icitoutv.png',
         'fanart': 'channels/ca/icitoutv_fanart.jpg',
-        'module': 'resources.lib.channels.ca.icitoutv',
         'enabled': True,
         'order': 8
     },
     'telemag': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ca/telemag:list_programs',
         'label': 'Télé-Mag',
         'thumb': 'channels/ca/telemag.png',
         'fanart': 'channels/ca/telemag_fanart.jpg',
-        'module': 'resources.lib.channels.ca.telemag',
         'enabled': True,
         'order': 9
     },
     'noovo': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ca/noovo:list_programs',
         'label': 'NOOVO',
         'thumb': 'channels/ca/noovo.png',
         'fanart': 'channels/ca/noovo_fanart.jpg',
-        'module': 'resources.lib.channels.ca.noovo',
         'enabled': True,
         'order': 10
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/ch_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/ch_live.py
@@ -30,163 +30,145 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'rougetv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/rougetv:get_live_url',
         'label': 'Rouge TV',
         'thumb': 'channels/ch/rougetv.png',
         'fanart': 'channels/ch/rougetv_fanart.jpg',
-        'module': 'resources.lib.channels.ch.rougetv',
         'enabled': True,
         'order': 6
     },
     'tvm3': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/tvm3:get_live_url',
         'label': 'TVM3',
         'thumb': 'channels/ch/tvm3.png',
         'fanart': 'channels/ch/tvm3_fanart.jpg',
-        'module': 'resources.lib.channels.ch.tvm3',
         'enabled': True,
         'order': 7
     },
     'rtsun': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTS Un',
         'thumb': 'channels/ch/rtsun.png',
         'fanart': 'channels/ch/rtsun_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 9
     },
     'rtsdeux': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTS Deux',
         'thumb': 'channels/ch/rtsdeux.png',
         'fanart': 'channels/ch/rtsdeux_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 10
     },
     'rtsinfo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTS Info',
         'thumb': 'channels/ch/rtsinfo.png',
         'fanart': 'channels/ch/rtsinfo_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 11
     },
     'rtscouleur3': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTS Couleur 3',
         'thumb': 'channels/ch/rtscouleur3.png',
         'fanart': 'channels/ch/rtscouleur3_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 12
     },
     'rsila1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTS La 1',
         'thumb': 'channels/ch/rsila1.png',
         'fanart': 'channels/ch/rsila1_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 13
     },
     'rsila2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTS La 2',
         'thumb': 'channels/ch/rsila2.png',
         'fanart': 'channels/ch/rsila2_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 14
     },
     'srf1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'SRF 1',
         'thumb': 'channels/ch/srf1.png',
         'fanart': 'channels/ch/srf1_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 15
     },
     'srfinfo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'SRF Info',
         'thumb': 'channels/ch/srfinfo.png',
         'fanart': 'channels/ch/srfinfo_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 16
     },
     'srfzwei': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'SRF Zwei',
         'thumb': 'channels/ch/srfzwei.png',
         'fanart': 'channels/ch/srfzwei_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 17
     },
     'rtraufsrf1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTR auf SRF 1',
         'thumb': 'channels/ch/rtraufsrf1.png',
         'fanart': 'channels/ch/rtraufsrf1_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 18
     },
     'rtraufsrfinfo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTR auf SRF Info',
         'thumb': 'channels/ch/rtraufsrfinfo.png',
         'fanart': 'channels/ch/rtraufsrfinfo_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 19
     },
     'rtraufsrf2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/srgssr:get_live_url',
         'label': 'RTR auf SRF 2',
         'thumb': 'channels/ch/rtraufsrf2.png',
         'fanart': 'channels/ch/rtraufsrf2_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 20
     },
     'teleticino': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/teleticino:get_live_url',
         'label': 'Teleticino',
         'thumb': 'channels/ch/teleticino.png',
         'fanart': 'channels/ch/teleticino_fanart.jpg',
-        'module': 'resources.lib.channels.ch.teleticino',
         'enabled': True,
         'order': 21
     },
     'lemanbleu': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/lemanbleu:get_live_url',
         'label': 'Léman Bleu',
         'thumb': 'channels/ch/lemanbleu.png',
         'fanart': 'channels/ch/lemanbleu_fanart.jpg',
-        'module': 'resources.lib.channels.ch.lemanbleu',
         'enabled': True,
         'order': 22
     },
     'telem1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/ch/telem1:get_live_url',
         'label': 'Tele M1',
         'thumb': 'channels/ch/telem1.png',
         'fanart': 'channels/ch/telem1_fanart.jpg',
-        'module': 'resources.lib.channels.ch.telem1',
         'enabled': True,
         'order': 23
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/ch_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/ch_replay.py
@@ -30,82 +30,73 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'rts': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/srgssr:list_categories',
         'label': 'RTS',
         'thumb': 'channels/ch/rts.png',
         'fanart': 'channels/ch/rts_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 1
     },
     'rsi': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/srgssr:list_categories',
         'label': 'RSI',
         'thumb': 'channels/ch/rsi.png',
         'fanart': 'channels/ch/rsi_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 2
     },
     'srf': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/srgssr:list_categories',
         'label': 'SRF',
         'thumb': 'channels/ch/srf.png',
         'fanart': 'channels/ch/srf_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 3
     },
     'rtr': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/srgssr:list_categories',
         'label': 'RTR',
         'thumb': 'channels/ch/rtr.png',
         'fanart': 'channels/ch/rtr_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 4
     },
     'swissinfo': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/srgssr:list_categories',
         'label': 'SWISSINFO',
         'thumb': 'channels/ch/swissinfo.png',
         'fanart': 'channels/ch/swissinfo_fanart.jpg',
-        'module': 'resources.lib.channels.ch.srgssr',
         'enabled': True,
         'order': 5
     },
     'tvm3': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/tvm3:list_programs',
         'label': 'TVM3',
         'thumb': 'channels/ch/tvm3.png',
         'fanart': 'channels/ch/tvm3_fanart.jpg',
-        'module': 'resources.lib.channels.ch.tvm3',
         'enabled': True,
         'order': 7
     },
     'becurioustv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/becurioustv:list_categories',
         'label': 'BeCurious TV',
         'thumb': 'channels/ch/becurioustv.png',
         'fanart': 'channels/ch/becurioustv_fanart.jpg',
-        'module': 'resources.lib.channels.ch.becurioustv',
         'enabled': True,
         'order': 8
     },
     'lemanbleu': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/ch/lemanbleu:list_programs',
         'label': 'Léman Bleu',
         'thumb': 'channels/ch/lemanbleu.png',
         'fanart': 'channels/ch/lemanbleu_fanart.jpg',
-        'module': 'resources.lib.channels.ch.lemanbleu',
         'enabled': True,
         'order': 22
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/cm_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/cm_live.py
@@ -30,28 +30,25 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'crtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cm/crtv:get_live_url',
         'label': 'CRTV',
         'thumb': 'channels/cm/crtv.png',
         'fanart': 'channels/cm/crtv_fanart.jpg',
-        'module': 'resources.lib.channels.cm.crtv',
         'enabled': True,
         'order': 1
     },
     'crtvnews': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cm/crtv:get_live_url',
         'label': 'CRTV News',
         'thumb': 'channels/cm/crtvnews.png',
         'fanart': 'channels/cm/crtvnews_fanart.jpg',
-        'module': 'resources.lib.channels.cm.crtv',
         'enabled': True,
         'order': 2
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/cm_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/cm_replay.py
@@ -30,10 +30,9 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {}

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/cn_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/cn_live.py
@@ -30,172 +30,153 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'cctv1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-1 综合',
         'thumb': 'channels/cn/cctv1.png',
         'fanart': 'channels/cn/cctv1_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 1
     },
     'cctv2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-2 财经',
         'thumb': 'channels/cn/cctv2.png',
         'fanart': 'channels/cn/cctv2_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 2
     },
     'cctv3': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-3 综艺',
         'thumb': 'channels/cn/cctv3.png',
         'fanart': 'channels/cn/cctv3_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 3
     },
     'cctv4': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-4 中文国际（亚）',
         'thumb': 'channels/cn/cctv4.png',
         'fanart': 'channels/cn/cctv4_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 4
     },
     'cctveurope': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-4 中文国际（欧）',
         'thumb': 'channels/cn/cctveurope.png',
         'fanart': 'channels/cn/cctveurope_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 5
     },
     'cctvamerica': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-4 中文国际（美）',
         'thumb': 'channels/cn/cctvamerica.png',
         'fanart': 'channels/cn/cctvamerica_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 6
     },
     'cctv5': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-5 体育',
         'thumb': 'channels/cn/cctv5.png',
         'fanart': 'channels/cn/cctv5_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 7
     },
     'cctv5plus': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-5+ 体育赛事',
         'thumb': 'channels/cn/cctv5plus.png',
         'fanart': 'channels/cn/cctv5plus_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 8
     },
     'cctv6': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-6 电影',
         'thumb': 'channels/cn/cctv6.png',
         'fanart': 'channels/cn/cctv6_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 9
     },
     'cctv7': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-7 军事农业',
         'thumb': 'channels/cn/cctv7.png',
         'fanart': 'channels/cn/cctv7_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 10
     },
     'cctv8': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-8 电视剧',
         'thumb': 'channels/cn/cctv8.png',
         'fanart': 'channels/cn/cctv8_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 11
     },
     'cctvjilu': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-9 纪录',
         'thumb': 'channels/cn/cctvjilu.png',
         'fanart': 'channels/cn/cctvjilu_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 12
     },
     'cctv10': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-10 科教',
         'thumb': 'channels/cn/cctv10.png',
         'fanart': 'channels/cn/cctv10_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 13
     },
     'cctv11': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-11 戏曲',
         'thumb': 'channels/cn/cctv11.png',
         'fanart': 'channels/cn/cctv11_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 14
     },
     'cctv12': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-12 社会与法',
         'thumb': 'channels/cn/cctv12.png',
         'fanart': 'channels/cn/cctv12_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 15
     },
     'cctv13': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-13 新闻',
         'thumb': 'channels/cn/cctv13.png',
         'fanart': 'channels/cn/cctv13_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 16
     },
     'cctvchild': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-14 少儿',
         'thumb': 'channels/cn/cctvchild.png',
         'fanart': 'channels/cn/cctvchild_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 17
     },
     'cctv15': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/cn/cctv:get_live_url',
         'label': 'CCTV-15 音乐',
         'thumb': 'channels/cn/cctv15.png',
         'fanart': 'channels/cn/cctv15_fanart.jpg',
-        'module': 'resources.lib.channels.cn.cctv',
         'enabled': True,
         'order': 18
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/cn_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/cn_replay.py
@@ -30,10 +30,9 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {}

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/es_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/es_live.py
@@ -30,92 +30,82 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'telecinco': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/mitele:get_live_url',
         'label': 'Telecinco',
         'thumb': 'channels/es/telecinco.png',
         'fanart': 'channels/es/telecinco_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 1
     },
     'cuatro': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/mitele:get_live_url',
         'label': 'Cuatro',
         'thumb': 'channels/es/cuatro.png',
         'fanart': 'channels/es/cuatro_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 2
     },
     'fdf': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/mitele:get_live_url',
         'label': 'Factoria de Ficcion',
         'thumb': 'channels/es/fdf.png',
         'fanart': 'channels/es/fdf_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 3
     },
     'boing': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/mitele:get_live_url',
         'label': 'Boing',
         'thumb': 'channels/es/boing.png',
         'fanart': 'channels/es/boing_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 4
     },
     'energy': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/mitele:get_live_url',
         'label': 'Energy TV',
         'thumb': 'channels/es/energy.png',
         'fanart': 'channels/es/energy_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 5
     },
     'divinity': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/mitele:get_live_url',
         'label': 'Divinity',
         'thumb': 'channels/es/divinity.png',
         'fanart': 'channels/es/divinity_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 6
     },
     'bemad': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/mitele:get_live_url',
         'label': 'Be Mad',
         'thumb': 'channels/es/bemad.png',
         'fanart': 'channels/es/bemad_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 7
     },
     'realmadridtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/realmadridtv:get_live_url',
         'label': 'Realmadrid TV (' + utils.ensure_unicode(Script.setting['realmadridtv.language']) + ')',
         'thumb': 'channels/es/realmadridtv.png',
         'fanart': 'channels/es/realmadridtv_fanart.jpg',
-        'module': 'resources.lib.channels.es.realmadridtv',
         'available_languages': ['EN', 'ES'],
         'enabled': True,
         'order': 8
     },
     'paramountchannel_es': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/es/paramountchannel_es:get_live_url',
         'label': 'Paramount Channel (ES)',
         'thumb': 'channels/es/paramountchannel_es.png',
         'fanart': 'channels/es/paramountchannel_es_fanart.jpg',
-        'module': 'resources.lib.channels.es.paramountchannel_es',
         'enabled': True,
         'order': 16
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/es_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/es_replay.py
@@ -30,19 +30,17 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'mitele': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/es/mitele:list_categories',
         'label': 'mitele',
         'thumb': 'channels/es/mitele.png',
         'fanart': 'channels/es/mitele_fanart.jpg',
-        'module': 'resources.lib.channels.es.mitele',
         'enabled': True,
         'order': 1
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/et_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/et_live.py
@@ -30,307 +30,273 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'ectv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'ECTV',
         'thumb': 'channels/et/ectv.png',
         'fanart': 'channels/et/ectv_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 1
     },
     'amma': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Amhara TV',
         'thumb': 'channels/et/amma.png',
         'fanart': 'channels/et/amma_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 2
     },
     'fbctv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Fana TV',
         'thumb': 'channels/et/fbctv.png',
         'fanart': 'channels/et/fbctv_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 3
     },
     'walta': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Walta TV',
         'thumb': 'channels/et/walta.png',
         'fanart': 'channels/et/walta_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 4
     },
     'etvz': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'EBC ZENA',
         'thumb': 'channels/et/etvz.png',
         'fanart': 'channels/et/etvz_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 5
     },
     'etvm': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'EBC MEZINAGNA',
         'thumb': 'channels/et/etvm.png',
         'fanart': 'channels/et/etvz_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 6
     },
     'etvq': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'EBC QUANQUAWOCH',
         'thumb': 'channels/et/etvq.png',
         'fanart': 'channels/et/etvq_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 7
     },
     'ltv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'LTV',
         'thumb': 'channels/et/ltv.png',
         'fanart': 'channels/et/ltv_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 8
     },
     'arts': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'ARTS TV',
         'thumb': 'channels/et/arts.png',
         'fanart': 'channels/et/arts_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 9
     },
     'moe': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'MoE',
         'thumb': 'channels/et/moe.png',
         'fanart': 'channels/et/moe_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 10
     },
     'nahoo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Nahoo TV',
         'thumb': 'channels/et/nahoo.png',
         'fanart': 'channels/et/nahoo_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 11
     },
     'obn': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'OBN',
         'thumb': 'channels/et/obn.png',
         'fanart': 'channels/et/obn_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 12
     },
     'obs': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'OBS',
         'thumb': 'channels/et/obs.png',
         'fanart': 'channels/et/obs_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 13
     },
     'tigrai': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Tigrai TV',
         'thumb': 'channels/et/tigrai.png',
         'fanart': 'channels/et/tigrai_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 14
     },
     'jtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'JTV ETHIOPIA',
         'thumb': 'channels/et/jtv.png',
         'fanart': 'channels/et/jtv_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 15
     },
     'esat': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'ESAT',
         'thumb': 'channels/et/esat.png',
         'fanart': 'channels/et/esat_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 16
     },
     'omn': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'OMN',
         'thumb': 'channels/et/omn.png',
         'fanart': 'channels/et/omn_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 17
     },
     'aleph': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Aleph TV',
         'thumb': 'channels/et/aleph.png',
         'fanart': 'channels/et/aleph_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 18
     },
     'bisrat': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Bisrat TV',
         'thumb': 'channels/et/bisrat.png',
         'fanart': 'channels/et/bisrat_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 19
     },
     'onn': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'ONN TV',
         'thumb': 'channels/et/onn.png',
         'fanart': 'channels/et/onn_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 20
     },
     'dws': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'DW TV',
         'thumb': 'channels/et/dws.png',
         'fanart': 'channels/et/dws_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 21
     },
     'adis': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Addis TV',
         'thumb': 'channels/et/adis.png',
         'fanart': 'channels/et/adis_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 22
     },
     'estv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'ES TV',
         'thumb': 'channels/et/estv.png',
         'fanart': 'channels/et/estv_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 23
     },
     'south': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Southern TV',
         'thumb': 'channels/et/south.png',
         'fanart': 'channels/et/south_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 24
     },
     'eritr': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Eritrea TV',
         'thumb': 'channels/et/eritr.png',
         'fanart': 'channels/et/eritr_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 25
     },
     'afri': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Afrihealth',
         'thumb': 'channels/et/afri.png',
         'fanart': 'channels/et/afri_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 26
     },
     'asham': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Asham TV',
         'thumb': 'channels/et/asham.png',
         'fanart': 'channels/et/asham_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 27
     },
     'ahadu': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Ahadu TV',
         'thumb': 'channels/et/ahadu.png',
         'fanart': 'channels/et/ahadu_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 28
     },
     'balage': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Balageru',
         'thumb': 'channels/et/balage.png',
         'fanart': 'channels/et/balage_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 29
     },
     'ava': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'AVA TV',
         'thumb': 'channels/et/ava.png',
         'fanart': 'channels/et/ava_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 30
     },
     'asrat': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'ASRAT MEDIA',
         'thumb': 'channels/et/asrat.png',
         'fanart': 'channels/et/asrat_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 31
     },
     'holys': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Holy Spirit TV',
         'thumb': 'channels/et/holys.png',
         'fanart': 'channels/et/holys_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 32
     },
     'gloryg': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/et/video2b:get_live_url',
         'label': 'Glory of GOD TV',
         'thumb': 'channels/et/gloryg.png',
         'fanart': 'channels/et/gloryg_fanart.jpg',
-        'module': 'resources.lib.channels.et.video2b',
         'enabled': True,
         'order': 33
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/fr_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/fr_live.py
@@ -30,19 +30,17 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'tf1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mytf1:get_live_url',
         'label': 'TF1',
         'thumb': 'channels/fr/tf1.png',
         'fanart': 'channels/fr/tf1_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mytf1',
         'xmltv_id': 'C192.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 1,
@@ -50,11 +48,10 @@ menu = {
         'order': 1
     },
     'france-2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/francetv:get_live_url',
         'label': 'France 2',
         'thumb': 'channels/fr/france2.png',
         'fanart': 'channels/fr/france2_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetv',
         'xmltv_id': 'C4.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 2,
@@ -62,11 +59,10 @@ menu = {
         'order': 2
     },
     'france-3': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/francetv:get_live_url',
         'label': 'France 3',
         'thumb': 'channels/fr/france3.png',
         'fanart': 'channels/fr/france3_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetv',
         'xmltv_id': 'C80.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 3,
@@ -74,11 +70,10 @@ menu = {
         'order': 3
     },
     'canalplus': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mycanal:get_live_url',
         'label': 'Canal +',
         'thumb': 'channels/fr/canalplus.png',
         'fanart': 'channels/fr/canalplus_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mycanal',
         'xmltv_id': 'C34.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 4,
@@ -86,11 +81,10 @@ menu = {
         'order': 4
     },
     'france-5': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/francetv:get_live_url',
         'label': 'France 5',
         'thumb': 'channels/fr/france5.png',
         'fanart': 'channels/fr/france5_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetv',
         'xmltv_id': 'C47.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 5,
@@ -98,11 +92,10 @@ menu = {
         'order': 5
     },
     'm6': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/6play:get_live_url',
         'label': 'M6',
         'thumb': 'channels/fr/m6.png',
         'fanart': 'channels/fr/m6_fanart.jpg',
-        'module': 'resources.lib.channels.fr.6play',
         'xmltv_id': 'C118.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 6,
@@ -110,11 +103,10 @@ menu = {
         'order': 6
     },
     'c8': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mycanal:get_live_url',
         'label': 'C8',
         'thumb': 'channels/fr/c8.png',
         'fanart': 'channels/fr/c8_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mycanal',
         'xmltv_id': 'C445.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 8,
@@ -122,11 +114,10 @@ menu = {
         'order': 7
     },
     'w9': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/6play:get_live_url',
         'label': 'W9',
         'thumb': 'channels/fr/w9.png',
         'fanart': 'channels/fr/w9_fanart.jpg',
-        'module': 'resources.lib.channels.fr.6play',
         'xmltv_id': 'C119.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 9,
@@ -134,11 +125,10 @@ menu = {
         'order': 8
     },
     'tmc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mytf1:get_live_url',
         'label': 'TMC',
         'thumb': 'channels/fr/tmc.png',
         'fanart': 'channels/fr/tmc_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mytf1',
         'xmltv_id': 'C195.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 10,
@@ -146,11 +136,10 @@ menu = {
         'order': 9
     },
     'tfx': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mytf1:get_live_url',
         'label': 'TFX',
         'thumb': 'channels/fr/tfx.png',
         'fanart': 'channels/fr/tfx_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mytf1',
         'xmltv_id': 'C446.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 11,
@@ -158,11 +147,10 @@ menu = {
         'order': 10
     },
     'nrj12': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/nrj:get_live_url',
         'label': 'NRJ 12',
         'thumb': 'channels/fr/nrj12.png',
         'fanart': 'channels/fr/nrj12_fanart.jpg',
-        'module': 'resources.lib.channels.fr.nrj',
         'xmltv_id': 'C444.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 12,
@@ -170,11 +158,10 @@ menu = {
         'order': 11
     },
     'france-4': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/francetv:get_live_url',
         'label': 'France 4',
         'thumb': 'channels/fr/france4.png',
         'fanart': 'channels/fr/france4_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetv',
         'xmltv_id': 'C78.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 14,
@@ -182,11 +169,10 @@ menu = {
         'order': 12
     },
     'bfmtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/bfmtv:get_live_url',
         'label': 'BFM TV',
         'thumb': 'channels/fr/bfmtv.png',
         'fanart': 'channels/fr/bfmtv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmtv',
         'xmltv_id': 'C481.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 15,
@@ -194,11 +180,10 @@ menu = {
         'order': 13
     },
     'cnews': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/cnews:get_live_url',
         'label': 'CNews',
         'thumb': 'channels/fr/cnews.png',
         'fanart': 'channels/fr/cnews_fanart.jpg',
-        'module': 'resources.lib.channels.fr.cnews',
         'xmltv_id': 'C226.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 16,
@@ -206,11 +191,10 @@ menu = {
         'order': 14
     },
     'cstar': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mycanal:get_live_url',
         'label': 'CStar',
         'thumb': 'channels/fr/cstar.png',
         'fanart': 'channels/fr/cstar_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mycanal',
         'xmltv_id': 'C458.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 17,
@@ -218,11 +202,10 @@ menu = {
         'order': 15
     },
     'gulli': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/gulli:get_live_url',
         'label': 'Gulli',
         'thumb': 'channels/fr/gulli.png',
         'fanart': 'channels/fr/gulli_fanart.jpg',
-        'module': 'resources.lib.channels.fr.gulli',
         'xmltv_id': 'C482.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 18,
@@ -230,11 +213,10 @@ menu = {
         'order': 16
     },
     'france-o': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/francetv:get_live_url',
         'label': 'France Ô',
         'thumb': 'channels/fr/franceo.png',
         'fanart': 'channels/fr/franceo_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetv',
         'xmltv_id': 'C160.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 19,
@@ -242,11 +224,10 @@ menu = {
         'order': 17
     },
     'tf1-series-films': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mytf1:get_live_url',
         'label': 'TF1 Séries Films',
         'thumb': 'channels/fr/tf1seriesfilms.png',
         'fanart': 'channels/fr/tf1seriesfilms_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mytf1',
         'xmltv_id': 'C1404.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 20,
@@ -254,11 +235,10 @@ menu = {
         'order': 18
     },
     'lequipe': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/lequipe:get_live_url',
         'label': 'L\'Équipe',
         'thumb': 'channels/fr/lequipe.png',
         'fanart': 'channels/fr/lequipe_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lequipe',
         'xmltv_id': 'C1401.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 21,
@@ -266,11 +246,10 @@ menu = {
         'order': 19
     },
     '6ter': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/6play:get_live_url',
         'label': '6ter',
         'thumb': 'channels/fr/6ter.png',
         'fanart': 'channels/fr/6ter_fanart.jpg',
-        'module': 'resources.lib.channels.fr.6play',
         'xmltv_id': 'C1403.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 22,
@@ -278,11 +257,10 @@ menu = {
         'order': 20
     },
     'rmcstory': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/rmc:get_live_url',
         'label': 'RMC Story',
         'thumb': 'channels/fr/rmcstory.png',
         'fanart': 'channels/fr/rmcstory_fanart.jpg',
-        'module': 'resources.lib.channels.fr.rmc',
         'xmltv_id': 'C1402.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 23,
@@ -290,11 +268,10 @@ menu = {
         'order': 21
     },
     'cherie25': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/nrj:get_live_url',
         'label': 'Chérie 25',
         'thumb': 'channels/fr/cherie25.png',
         'fanart': 'channels/fr/cherie25_fanart.jpg',
-        'module': 'resources.lib.channels.fr.nrj',
         'xmltv_id': 'C1399.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 25,
@@ -302,15 +279,12 @@ menu = {
         'order': 22
     },
     'la_1ere': {
-        'callback':
-        'live_bridge',
+        'resolver': '/resources/lib/channels/fr/la_1ere:get_live_url',
         'label': 'La 1ère (' + utils.ensure_unicode(Script.setting['la_1ere.language']) + ')',
         'thumb':
         'channels/fr/la1ere.png',
         'fanart':
         'channels/fr/la1ere_fanart.jpg',
-        'module':
-        'resources.lib.channels.fr.la_1ere',
         'm3u_group':
         'Région',
         'available_languages': [
@@ -322,11 +296,10 @@ menu = {
         'order': 23
     },
     'franceinfo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/franceinfo:get_live_url',
         'label': 'France Info',
         'thumb': 'channels/fr/franceinfo.png',
         'fanart': 'channels/fr/franceinfo_fanart.jpg',
-        'module': 'resources.lib.channels.fr.franceinfo',
         'xmltv_id': 'C2111.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 27,
@@ -334,22 +307,20 @@ menu = {
         'order': 24
     },
     'bfmbusiness': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/bfmtv:get_live_url',
         'label': 'BFM Business',
         'thumb': 'channels/fr/bfmbusiness.png',
         'fanart': 'channels/fr/bfmbusiness_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmtv',
         'xmltv_id': 'C1073.api.telerama.fr',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 25
     },
     'lci': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/lci:get_live_url',
         'label': 'LCI',
         'thumb': 'channels/fr/lci.png',
         'fanart': 'channels/fr/lci_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lci',
         'xmltv_id': 'C112.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 26,
@@ -357,11 +328,10 @@ menu = {
         'order': 30
     },
     'lcp': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/lcp:get_live_url',
         'label': 'LCP Assemblée Nationale',
         'thumb': 'channels/fr/lcp.png',
         'fanart': 'channels/fr/lcp_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lcp',
         'xmltv_id': 'C234.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 13,
@@ -369,11 +339,10 @@ menu = {
         'order': 31
     },
     'rmcdecouverte': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/rmc:get_live_url',
         'label': 'RMC Découverte',
         'thumb': 'channels/fr/rmcdecouverte.png',
         'fanart': 'channels/fr/rmcdecouverte_fanart.jpg',
-        'module': 'resources.lib.channels.fr.rmc',
         'xmltv_id': 'C1400.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 24,
@@ -381,11 +350,10 @@ menu = {
         'order': 32
     },
     'publicsenat': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/publicsenat:get_live_url',
         'label': 'Public Sénat',
         'thumb': 'channels/fr/publicsenat.png',
         'fanart': 'channels/fr/publicsenat_fanart.jpg',
-        'module': 'resources.lib.channels.fr.publicsenat',
         'xmltv_id': 'C234.api.telerama.fr',
         'm3u_group': 'TNT',
         'm3u_order': 13,
@@ -393,15 +361,12 @@ menu = {
         'order': 39
     },
     'france3regions': {
-        'callback':
-        'live_bridge',
+        'resolver': '/resources/lib/channels/fr/france3regions:get_live_url',
         'label': 'France 3 Régions (' + utils.ensure_unicode(Script.setting['france3regions.language']) + ')',
         'thumb':
         'channels/fr/france3regions.png',
         'fanart':
         'channels/fr/france3regions_fanart.jpg',
-        'module':
-        'resources.lib.channels.fr.france3regions',
         'm3u_group':
         'Région',
         'available_languages': [
@@ -417,472 +382,425 @@ menu = {
         'order': 40
     },
     'francetvsport': {
-        'callback': 'multi_live_bridge',
+        'route': '/resources/lib/channels/fr/francetvsport:list_lives',
         'label': 'France TV Sport (francetv)',
         'thumb': 'channels/fr/francetvsport.png',
         'fanart': 'channels/fr/francetvsport_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetvsport',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 41
     },
     'gong': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/gong:get_live_url',
         'label': 'Gong',
         'thumb': 'channels/fr/gong.png',
         'fanart': 'channels/fr/gong_fanart.jpg',
-        'module': 'resources.lib.channels.fr.gong',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 55
     },
     'bfmparis': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/bfmregion:get_live_url',
         'label': 'BFM Paris',
         'thumb': 'channels/fr/bfmparis.png',
         'fanart': 'channels/fr/bfmparis_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 56
     },
     'fun_radio': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/6play:get_live_url',
         'label': 'Fun Radio',
         'thumb': 'channels/fr/funradio.png',
         'fanart': 'channels/fr/funradio_fanart.jpg',
-        'module': 'resources.lib.channels.fr.6play',
         'm3u_group': 'Radio',
         'enabled': True,
         'order': 58
     },
     'kto': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/kto:get_live_url',
         'label': 'KTO',
         'thumb': 'channels/fr/kto.png',
         'fanart': 'channels/fr/kto_fanart.jpg',
-        'module': 'resources.lib.channels.fr.kto',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 64
     },
     'antennereunion': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/antennereunion:get_live_url',
         'label': 'Antenne Réunion',
         'thumb': 'channels/fr/antennereunion.png',
         'fanart': 'channels/fr/antennereunion_fanart.jpg',
-        'module': 'resources.lib.channels.fr.antennereunion',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 65
     },
     'viaoccitanie': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/via:get_live_url',
         'label': 'viàOccitanie',
         'thumb': 'channels/fr/viaoccitanie.png',
         'fanart': 'channels/fr/viaoccitanie_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 66
     },
     'ouatchtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/ouatchtv:get_live_url',
         'label': 'Ouatch TV',
         'thumb': 'channels/fr/ouatchtv.png',
         'fanart': 'channels/fr/ouatchtv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.ouatchtv',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 67
     },
     'canal10': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/canal10:get_live_url',
         'label': 'Canal 10',
         'thumb': 'channels/fr/canal10.png',
         'fanart': 'channels/fr/canal10_fanart.jpg',
-        'module': 'resources.lib.channels.fr.canal10',
         'm3u_group': 'Région',
         'enabled': False,
         'order': 68
     },
     'rtl2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/6play:get_live_url',
         'label': 'RTL 2',
         'thumb': 'channels/fr/rtl2.png',
         'fanart': 'channels/fr/rtl2_fanart.jpg',
-        'module': 'resources.lib.channels.fr.6play',
         'm3u_group': 'Radio',
         'enabled': True,
         'order': 69
     },
     'viaatv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/via:get_live_url',
         'label': 'viàATV',
         'thumb': 'channels/fr/viaatv.png',
         'fanart': 'channels/fr/viaatv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 72
     },
     'viagrandparis': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/via:get_live_url',
         'label': 'viàGrandParis',
         'thumb': 'channels/fr/viagrandparis.png',
         'fanart': 'channels/fr/viagrandparis_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 73
     },
     'tebeo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tebeo:get_live_url',
         'label': 'Tébéo',
         'thumb': 'channels/fr/tebeo.png',
         'fanart': 'channels/fr/tebeo_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tebeo',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 77
     },
     'mb': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/6play:get_live_url',
         'label': 'M6 Boutique',
         'thumb': 'channels/fr/mb.png',
         'fanart': 'channels/fr/mb_fanart.jpg',
-        'module': 'resources.lib.channels.fr.6play',
         'xmltv_id': 'C184.api.telerama.fr',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 78
     },
     'vialmtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/via:get_live_url',
         'label': 'viàLMTv Sarthe',
         'thumb': 'channels/fr/vialmtv.png',
         'fanart': 'channels/fr/vialmtv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 79
     },
     'viamirabelle': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/via:get_live_url',
         'label': 'viàMirabelle',
         'thumb': 'channels/fr/viamirabelle.png',
         'fanart': 'channels/fr/viamirabelle_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 80
     },
     'viavosges': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/via:get_live_url',
         'label': 'viàVosges',
         'thumb': 'channels/fr/viavosges.png',
         'fanart': 'channels/fr/viavosges_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 81
     },
     'tl7': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tl7:get_live_url',
         'label': 'Télévision Loire 7',
         'thumb': 'channels/fr/tl7.png',
         'fanart': 'channels/fr/tl7_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tl7',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 82
     },
     'luckyjack': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/abweb:get_live_url',
         'label': 'Lucky Jack',
         'thumb': 'channels/fr/luckyjack.png',
         'fanart': 'channels/fr/luckyjack_fanart.jpg',
-        'module': 'resources.lib.channels.fr.abweb',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 83
     },
     'mblivetv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/mblivetv:get_live_url',
         'label': 'Mont Blanc Live TV',
         'thumb': 'channels/fr/mblivetv.png',
         'fanart': 'channels/fr/mblivetv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mblivetv',
         'm3u_group': 'Satellite/FAI',
         'enabled': False,
         'order': 84
     },
     'tv8montblanc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tv8montblanc:get_live_url',
         'label': '8 Mont-Blanc',
         'thumb': 'channels/fr/tv8montblanc.png',
         'fanart': 'channels/fr/tv8montblanc_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tv8montblanc',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 85
     },
     'alsace20': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/alsace20:get_live_url',
         'label': 'Alsace 20',
         'thumb': 'channels/fr/alsace20.png',
         'fanart': 'channels/fr/alsace20_fanart.jpg',
-        'module': 'resources.lib.channels.fr.alsace20',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 87
     },
     'tvpifr': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tvpifr:get_live_url',
         'label': 'TVPI télévision d\'ici',
         'thumb': 'channels/fr/tvpifr.png',
         'fanart': 'channels/fr/tvpifr_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tvpifr',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 89
     },
     'idf1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/idf1:get_live_url',
         'label': 'IDF 1',
         'thumb': 'channels/fr/idf1.png',
         'fanart': 'channels/fr/idf1_fanart.jpg',
-        'module': 'resources.lib.channels.fr.idf1',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 95
     },
     'azurtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/azurtv:get_live_url',
         'label': 'Azur TV',
         'thumb': 'channels/fr/azurtv.png',
         'fanart': 'channels/fr/azurtv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.azurtv',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 96
     },
     'biptv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/biptv:get_live_url',
         'label': 'BIP TV',
         'thumb': 'channels/fr/biptv.png',
         'fanart': 'channels/fr/biptv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.biptv',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 97
     },
     'bfmlille': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/bfmregion:get_live_url',
         'label': 'BFM Lille',
         'thumb': 'channels/fr/bfmlille.png',
         'fanart': 'channels/fr/bfmlille_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 98
     },
     'bfmgrandlittoral': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/bfmregion:get_live_url',
         'label': 'BFM Littoral',
         'thumb': 'channels/fr/bfmgrandlittoral.png',
         'fanart': 'channels/fr/bfmgrandlittoral_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 99
     },
     'lachainenormande': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/lachainenormande:get_live_url',
         'label': 'La Chaine Normande',
         'thumb': 'channels/fr/lachainenormande.png',
         'fanart': 'channels/fr/lachainenormande_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lachainenormande',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 100
     },
     'sportenfrance': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/sportenfrance:get_live_url',
         'label': 'Sport en France',
         'thumb': 'channels/fr/sportenfrance.png',
         'fanart': 'channels/fr/sportenfrance_fanart.jpg',
-        'module': 'resources.lib.channels.fr.sportenfrance',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 101
     },
     'provenceazurtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/azurtv:get_live_url',
         'label': 'Provence Azur TV',
         'thumb': 'channels/fr/provenceazurtv.png',
         'fanart': 'channels/fr/provenceazurtv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.azurtv',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 102
     },
     'tebesud': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tebeo:get_live_url',
         'label': 'TébéSud',
         'thumb': 'channels/fr/tebesud.png',
         'fanart': 'channels/fr/tebesud_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tebeo',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 103
     },
     'telegrenoble': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/telegrenoble:get_live_url',
         'label': 'TéléGrenoble',
         'thumb': 'channels/fr/telegrenoble.png',
         'fanart': 'channels/fr/telegrenoble_fanart.jpg',
-        'module': 'resources.lib.channels.fr.telegrenoble',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 105
     },
     'telenantes': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/telenantes:get_live_url',
         'label': 'TéléNantes',
         'thumb': 'channels/fr/telenantes.png',
         'fanart': 'channels/fr/telenantes_fanart.jpg',
-        'module': 'resources.lib.channels.fr.telenantes',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 106
     },
     'bfmlyon': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/bfmregion:get_live_url',
         'label': 'BFM Lyon',
         'thumb': 'channels/fr/bfmlyon.png',
         'fanart': 'channels/fr/bfmlyon_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 107
     },
     'tlc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tlc:get_live_url',
         'label': 'TLC',
         'thumb': 'channels/fr/tlc.png',
         'fanart': 'channels/fr/tlc_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tlc',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 108
     },
     'tvvendee': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tvvendee:get_live_url',
         'label': 'TV Vendée',
         'thumb': 'channels/fr/tvvendee.png',
         'fanart': 'channels/fr/tvvendee_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tvvendee',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 109
     },
     'tv7bordeaux': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tv7bordeaux:get_live_url',
         'label': 'TV7 Bordeaux',
         'thumb': 'channels/fr/tv7bordeaux.png',
         'fanart': 'channels/fr/tv7bordeaux_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tv7bordeaux',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 110
     },
     'tvt': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tvt:get_live_url',
         'label': 'TVT Val de Loire',
         'thumb': 'channels/fr/tvt.png',
         'fanart': 'channels/fr/tvt_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tvt',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 111
     },
     'tvr': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/tvr:get_live_url',
         'label': 'TVR',
         'thumb': 'channels/fr/tvr.png',
         'fanart': 'channels/fr/tvr_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tvr',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 112
     },
     'weo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/weo:get_live_url',
         'label': 'Wéo TV',
         'thumb': 'channels/fr/weo.png',
         'fanart': 'channels/fr/weo_fanart.jpg',
-        'module': 'resources.lib.channels.fr.weo',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 113
     },
     'dicitv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/dicitv:get_live_url',
         'label': 'DiCi TV',
         'thumb': 'channels/fr/dicitv.png',
         'fanart': 'channels/fr/dicitv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.dicitv',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 114
     },
     'viamatele': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/via:get_live_url',
         'label': 'viàMaTélé',
         'thumb': 'channels/fr/viamatele.png',
         'fanart': 'channels/fr/viamatele_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'm3u_group': 'Région',
         'enabled': True,
         'order': 115
     },
     'franceinter': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/franceinter:get_live_url',
         'label': 'France Inter',
         'thumb': 'channels/fr/franceinter.png',
         'fanart': 'channels/fr/franceinter_fanart.jpg',
-        'module': 'resources.lib.channels.fr.franceinter',
         'm3u_group': 'Radio',
         'enabled': True,
         'order': 116
     },
     'rtl': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/rtl:get_live_url',
         'label': 'RTL',
         'thumb': 'channels/fr/rtl.png',
         'fanart': 'channels/fr/rtl_fanart.jpg',
-        'module': 'resources.lib.channels.fr.rtl',
         'm3u_group': 'Radio',
         'enabled': True,
         'order': 118
     },
     'europe1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/europe1:get_live_url',
         'label': 'Europe 1',
         'thumb': 'channels/fr/europe1.png',
         'fanart': 'channels/fr/europe1_fanart.jpg',
-        'module': 'resources.lib.channels.fr.europe1',
         'm3u_group': 'Radio',
         'enabled': True,
         'order': 120
     },
     '01net': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/fr/01net:get_live_url',
         'label': '01Net TV',
         'thumb': 'channels/fr/01net.png',
         'fanart': 'channels/fr/01net_fanart.jpg',
-        'module': 'resources.lib.channels.fr.01net',
         'm3u_group': 'Satellite/FAI',
         'enabled': True,
         'order': 121

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/fr_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/fr_replay.py
@@ -30,460 +30,409 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'mytf1': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/mytf1:mytf1_root',
         'label': 'MYTF1',
         'thumb': 'channels/fr/mytf1.png',
         'fanart': 'channels/fr/mytf1_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mytf1',
         'enabled': True,
         'order': 1
     },
     'francetv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/francetv:francetv_root',
         'label': 'france.tv',
         'thumb': 'channels/fr/francetv.png',
         'fanart': 'channels/fr/francetv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetv',
         'enabled': True,
         'order': 2
     },
     'mycanal': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/mycanal:mycanal_root',
         'label': 'myCANAL',
         'thumb': 'channels/fr/mycanal.png',
         'fanart': 'channels/fr/mycanal_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mycanal',
         'enabled': True,
         'order': 4
     },
     '6play': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/6play:sixplay_root',
         'label': '6play',
         'thumb': 'channels/fr/6play.png',
         'fanart': 'channels/fr/6play_fanart.jpg',
-        'module': 'resources.lib.channels.fr.6play',
         'enabled': True,
         'order': 6
     },
     'nrjplay': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/nrj:nrjplay_root',
         'label': 'NRJ Play',
         'thumb': 'channels/fr/nrjplay.png',
         'fanart': 'channels/fr/nrjplay_fanart.jpg',
-        'module': 'resources.lib.channels.fr.nrj',
         'enabled': True,
         'order': 11
     },
     'bfmtv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmtv:list_programs',
         'label': 'BFM TV',
         'thumb': 'channels/fr/bfmtv.png',
         'fanart': 'channels/fr/bfmtv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmtv',
         'enabled': True,
         'order': 13
     },
     'cnews': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/cnews:list_categories',
         'label': 'CNews',
         'thumb': 'channels/fr/cnews.png',
         'fanart': 'channels/fr/cnews_fanart.jpg',
-        'module': 'resources.lib.channels.fr.cnews',
         'enabled': True,
         'order': 14
     },
     'gulli': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/gulli:list_categories',
         'label': 'Gulli',
         'thumb': 'channels/fr/gulli.png',
         'fanart': 'channels/fr/gulli_fanart.jpg',
-        'module': 'resources.lib.channels.fr.gulli',
         'enabled': True,
         'order': 16
     },
     'lequipe': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/lequipe:list_programs',
         'label': 'L\'Équipe',
         'thumb': 'channels/fr/lequipe.png',
         'fanart': 'channels/fr/lequipe_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lequipe',
         'enabled': True,
         'order': 19
     },
     'rmcstory': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/rmc:list_categories',
         'label': 'RMC Story',
         'thumb': 'channels/fr/rmcstory.png',
         'fanart': 'channels/fr/rmcstory_fanart.jpg',
-        'module': 'resources.lib.channels.fr.rmc',
         'enabled': True,
         'order': 21
     },
     'la_1ere': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/la_1ere:list_programs',
         'label': 'La 1ère (' + utils.ensure_unicode(Script.setting['la_1ere.language']) + ')',
         'thumb': 'channels/fr/la1ere.png',
         'fanart': 'channels/fr/la1ere_fanart.jpg',
-        'module': 'resources.lib.channels.fr.la_1ere',
         'enabled': False,
         'order': 23
     },
     'franceinfo': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/franceinfo:list_categories',
         'label': 'France Info',
         'thumb': 'channels/fr/franceinfo.png',
         'fanart': 'channels/fr/franceinfo_fanart.jpg',
-        'module': 'resources.lib.channels.fr.franceinfo',
         'enabled': True,
         'order': 24
     },
     'bfmbusiness': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmtv:list_programs',
         'label': 'BFM Business',
         'thumb': 'channels/fr/bfmbusiness.png',
         'fanart': 'channels/fr/bfmbusiness_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmtv',
         'enabled': True,
         'order': 25
     },
     'rmc': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmtv:list_programs',
         'label': 'RMC',
         'thumb': 'channels/fr/rmc.png',
         'fanart': 'channels/fr/rmc_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmtv',
         'enabled': True,
         'order': 26
     },
     '01net': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmtv:list_programs',
         'label': '01Net TV',
         'thumb': 'channels/fr/01net.png',
         'fanart': 'channels/fr/01net_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmtv',
         'enabled': True,
         'order': 27
     },
     'lci': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/lci:list_programs',
         'label': 'LCI',
         'thumb': 'channels/fr/lci.png',
         'fanart': 'channels/fr/lci_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lci',
         'enabled': True,
         'order': 30
     },
     'lcp': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/lcp:list_categories',
         'label': 'LCP Assemblée Nationale',
         'thumb': 'channels/fr/lcp.png',
         'fanart': 'channels/fr/lcp_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lcp',
         'enabled': True,
         'order': 31
     },
     'rmcdecouverte': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/rmc:list_categories',
         'label': 'RMC Découverte',
         'thumb': 'channels/fr/rmcdecouverte.png',
         'fanart': 'channels/fr/rmcdecouverte_fanart.jpg',
-        'module': 'resources.lib.channels.fr.rmc',
         'enabled': True,
         'order': 32
     },
     'publicsenat': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/publicsenat:list_categories',
         'label': 'Public Sénat',
         'thumb': 'channels/fr/publicsenat.png',
         'fanart': 'channels/fr/publicsenat_fanart.jpg',
-        'module': 'resources.lib.channels.fr.publicsenat',
         'enabled': True,
         'order': 39
     },
     'france3regions': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/france3regions:list_programs',
         'label': 'France 3 Régions (' + utils.ensure_unicode(Script.setting['france3regions.language']) + ')',
         'thumb': 'channels/fr/france3regions.png',
         'fanart': 'channels/fr/france3regions_fanart.jpg',
-        'module': 'resources.lib.channels.fr.france3regions',
         'enabled': False,
         'order': 40
     },
     'francetvsport': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/francetvsport:list_categories',
         'label': 'France TV Sport (francetv)',
         'thumb': 'channels/fr/francetvsport.png',
         'fanart': 'channels/fr/francetvsport_fanart.jpg',
-        'module': 'resources.lib.channels.fr.francetvsport',
         'enabled': True,
         'order': 41
     },
     'histoire': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tf1thematiques:list_categories',
         'label': 'Histoire',
         'thumb': 'channels/fr/histoire.png',
         'fanart': 'channels/fr/histoire_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tf1thematiques',
         'enabled': True,
         'order': 42
     },
     'tvbreizh': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tf1thematiques:list_categories',
         'label': 'TV Breizh',
         'thumb': 'channels/fr/tvbreizh.png',
         'fanart': 'channels/fr/tvbreizh_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tf1thematiques',
         'enabled': True,
         'order': 43
     },
     'ushuaiatv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tf1thematiques:list_categories',
         'label': 'Ushuaïa TV',
         'thumb': 'channels/fr/ushuaiatv.png',
         'fanart': 'channels/fr/ushuaiatv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tf1thematiques',
         'enabled': True,
         'order': 44
     },
     'gameone': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/gameone:list_programs',
         'label': 'Game One',
         'thumb': 'channels/fr/gameone.png',
         'fanart': 'channels/fr/gameone_fanart.jpg',
-        'module': 'resources.lib.channels.fr.gameone',
         'enabled': True,
         'order': 53
     },
     'lumni': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/lumni:list_categories',
         'label': 'Lumni (francetv)',
         'thumb': 'channels/fr/lumni.png',
         'fanart': 'channels/fr/lumni_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lumni',
         'enabled': True,
         'order': 54
     },
     'gong': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/gong:list_categories',
         'label': 'Gong',
         'thumb': 'channels/fr/gong.png',
         'fanart': 'channels/fr/gong_fanart.jpg',
-        'module': 'resources.lib.channels.fr.gong',
         'enabled': True,
         'order': 55
     },
     'bfmparis': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmregion:list_categories',
         'label': 'BFM Paris',
         'thumb': 'channels/fr/bfmparis.png',
         'fanart': 'channels/fr/bfmparis_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'enabled': True,
         'order': 56
     },
     'kto': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/kto:list_categories',
         'label': 'KTO',
         'thumb': 'channels/fr/kto.png',
         'fanart': 'channels/fr/kto_fanart.jpg',
-        'module': 'resources.lib.channels.fr.kto',
         'enabled': True,
         'order': 64
     },
     'antennereunion': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/antennereunion:list_categories',
         'label': 'Antenne Réunion',
         'thumb': 'channels/fr/antennereunion.png',
         'fanart': 'channels/fr/antennereunion_fanart.jpg',
-        'module': 'resources.lib.channels.fr.antennereunion',
         'enabled': True,
         'order': 65
     },
     'ouatchtv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/ouatchtv:list_programs',
         'label': 'Ouatch TV',
         'thumb': 'channels/fr/ouatchtv.png',
         'fanart': 'channels/fr/ouatchtv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.ouatchtv',
         'enabled': True,
         'order': 67
     },
     'lachainemeteo': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/lachainemeteo:list_programs',
         'label': 'La Chaîne Météo',
         'thumb': 'channels/fr/lachainemeteo.png',
         'fanart': 'channels/fr/lachainemeteo_fanart.jpg',
-        'module': 'resources.lib.channels.fr.lachainemeteo',
         'enabled': True,
         'order': 70
     },
     'j_one': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/j_one:list_videos',
         'label': 'J-One',
         'thumb': 'channels/fr/jone.png',
         'fanart': 'channels/fr/jone_fanart.jpg',
-        'module': 'resources.lib.channels.fr.j_one',
         'enabled': True,
         'order': 71
     },
     'via93': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/via:list_categories',
         'label': 'vià93',
         'thumb': 'channels/fr/via93.png',
         'fanart': 'channels/fr/via93_fanart.jpg',
-        'module': 'resources.lib.channels.fr.via',
         'enabled': True,
         'order': 74
     },
     'jack': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/jack:list_programs',
         'label': 'Jack (mycanal)',
         'thumb': 'channels/fr/jack.png',
         'fanart': 'channels/fr/jack_fanart.jpg',
-        'module': 'resources.lib.channels.fr.jack',
         'enabled': True,
         'order': 75
     },
     'caledonia': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/caledonia:list_programs',
         'label': 'Caledonia',
         'thumb': 'channels/fr/caledonia.png',
         'fanart': 'channels/fr/caledonia_fanart.jpg',
-        'module': 'resources.lib.channels.fr.caledonia',
         'enabled': True,
         'order': 76
     },
     'tebeo': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tebeo:list_categories',
         'label': 'Tébéo',
         'thumb': 'channels/fr/tebeo.png',
         'fanart': 'channels/fr/tebeo_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tebeo',
         'enabled': True,
         'order': 77
     },
     'tl7': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tl7:list_programs',
         'label': 'Télévision Loire 7',
         'thumb': 'channels/fr/tl7.png',
         'fanart': 'channels/fr/tl7_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tl7',
         'enabled': True,
         'order': 82
     },
     'mblivetv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/mblivetv:list_videos',
         'label': 'Mont Blanc Live TV',
         'thumb': 'channels/fr/mblivetv.png',
         'fanart': 'channels/fr/mblivetv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mblivetv',
         'enabled': True,
         'order': 84
     },
     'tv8montblanc': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tv8montblanc:list_videos',
         'label': '8 Mont-Blanc',
         'thumb': 'channels/fr/tv8montblanc.png',
         'fanart': 'channels/fr/tv8montblanc_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tv8montblanc',
         'enabled': True,
         'order': 85
     },
     'luxetv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/luxetv:list_categories',
         'label': 'Luxe.TV',
         'thumb': 'channels/fr/luxetv.png',
         'fanart': 'channels/fr/luxetv_fanart.jpg',
-        'module': 'resources.lib.channels.fr.luxetv',
         'enabled': True,
         'order': 86
     },
     'alsace20': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/alsace20:list_categories',
         'label': 'Alsace 20',
         'thumb': 'channels/fr/alsace20.png',
         'fanart': 'channels/fr/alsace20_fanart.jpg',
-        'module': 'resources.lib.channels.fr.alsace20',
         'enabled': True,
         'order': 87
     },
     'tvpifr': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tvpifr:TOTO',
         'label': 'TVPI télévision d\'ici',
         'thumb': 'channels/fr/tvpifr.png',
         'fanart': 'channels/fr/tvpifr_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tvpifr',
         'enabled': True,
         'order': 89
     },
     'paramountchannel_fr': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/paramountchannel_fr:list_categories',
         'label': 'Paramount Channel (FR)',
         'thumb': 'channels/fr/paramountchannel_fr.png',
         'fanart': 'channels/fr/paramountchannel_fr_fanart.jpg',
-        'module': 'resources.lib.channels.fr.paramountchannel_fr',
         'enabled': True,
         'order': 93
     },
     'mtv_fr': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/mtv_fr:list_categories',
         'label': 'MTV (FR)',
         'thumb': 'channels/fr/mtv_fr.png',
         'fanart': 'channels/fr/mtv_fr_fanart.jpg',
-        'module': 'resources.lib.channels.fr.mtv_fr',
         'enabled': True,
         'order': 94
     },
     'bfmlille': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmregion:list_categories',
         'label': 'BFM Lille',
         'thumb': 'channels/fr/bfmlille.png',
         'fanart': 'channels/fr/bfmlille_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'enabled': True,
         'order': 98
     },
     'bfmgrandlittoral': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmregion:list_categories',
         'label': 'BFM Littoral',
         'thumb': 'channels/fr/bfmgrandlittoral.png',
         'fanart': 'channels/fr/bfmgrandlittoral_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'enabled': True,
         'order': 99
     },
     'tebesud': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/tebeo:list_categories',
         'label': 'TébéSud',
         'thumb': 'channels/fr/tebesud.png',
         'fanart': 'channels/fr/tebesud_fanart.jpg',
-        'module': 'resources.lib.channels.fr.tebeo',
         'enabled': True,
         'order': 103
     },
     'telegrenoble': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/telegrenoble:list_categories',
         'label': 'TéléGrenoble',
         'thumb': 'channels/fr/telegrenoble.png',
         'fanart': 'channels/fr/telegrenoble_fanart.jpg',
-        'module': 'resources.lib.channels.fr.telegrenoble',
         'enabled': True,
         'order': 105
     },
     'bfmlyon': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/fr/bfmregion:list_categories',
         'label': 'BFM Lyon',
         'thumb': 'channels/fr/bfmlyon.png',
         'fanart': 'channels/fr/bfmlyon_fanart.jpg',
-        'module': 'resources.lib.channels.fr.bfmregion',
         'enabled': True,
         'order': 107
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/it_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/it_live.py
@@ -30,159 +30,143 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'la7': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/la7:get_live_url',
         'label': 'La7',
         'thumb': 'channels/it/la7.png',
         'fanart': 'channels/it/la7_fanart.jpg',
-        'module': 'resources.lib.channels.it.la7',
         'xmltv_id': 'www.la7.it',
         'enabled': True,
         'order': 1
     },
     'rainews24': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai News 24',
         'thumb': 'channels/it/rainews24.png',
         'fanart': 'channels/it/rainews24_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'rainews.guidatv.sky.it',
         'enabled': True,
         'order': 2
     },
     'rai1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai 1',
         'thumb': 'channels/it/rai1.png',
         'fanart': 'channels/it/rai1_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'www.raiuno.rai.it',
         'enabled': True,
         'order': 3
     },
     'rai2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai 2',
         'thumb': 'channels/it/rai2.png',
         'fanart': 'channels/it/rai2_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'www.raidue.rai.it',
         'enabled': True,
         'order': 4
     },
     'rai3': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai 3',
         'thumb': 'channels/it/rai3.png',
         'fanart': 'channels/it/rai3_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'www.raitre.rai.it',
         'enabled': True,
         'order': 5
     },
     'rai4': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai 4',
         'thumb': 'channels/it/rai4.png',
         'fanart': 'channels/it/rai4_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'rai4.raisat.it',
         'enabled': True,
         'order': 6
     },
     'rai5': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai 5',
         'thumb': 'channels/it/rai5.png',
         'fanart': 'channels/it/rai5_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'rai5.rai.it',
         'enabled': True,
         'order': 7
     },
     'raisportpiuhd': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai Sport',
         'thumb': 'channels/it/raisportpiuhd.png',
         'fanart': 'channels/it/raisportpiuhd_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'raisport.guidatv.sky.it',
         'enabled': True,
         'order': 8
     },
     'raimovie': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai Movie',
         'thumb': 'channels/it/raimovie.png',
         'fanart': 'channels/it/raimovie_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'raimovie.rai.it',
         'enabled': True,
         'order': 9
     },
     'raipremium': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai Premium',
         'thumb': 'channels/it/raipremium.png',
         'fanart': 'channels/it/raipremium_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'raipremium.guidatv.sky.it',
         'enabled': True,
         'order': 10
     },
     'raiyoyo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai Yoyo',
         'thumb': 'channels/it/raiyoyo.png',
         'fanart': 'channels/it/raiyoyo_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'yoyo.raisat.it',
         'enabled': True,
         'order': 11
     },
     'raigulp': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai Gulp',
         'thumb': 'channels/it/raigulp.png',
         'fanart': 'channels/it/raigulp_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'raigulp.rai.it',
         'enabled': True,
         'order': 12
     },
     'raistoria': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai Storia',
         'thumb': 'channels/it/raistoria.png',
         'fanart': 'channels/it/raistoria_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'raistoria.rai.it',
         'enabled': True,
         'order': 13
     },
     'raiscuola': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/raiplay:get_live_url',
         'label': 'Rai Scuola',
         'thumb': 'channels/it/raiscuola.png',
         'fanart': 'channels/it/raiscuola_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'xmltv_id': 'raiscuola.rai.it',
         'enabled': True,
         'order': 14
     },
     'paramountchannel_it': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/it/paramountchannel_it:get_live_url',
         'label': 'Paramount Channel (IT)',
         'thumb': 'channels/it/paramountchannel_it.png',
         'fanart': 'channels/it/paramountchannel_it_fanart.jpg',
-        'module': 'resources.lib.channels.it.paramountchannel_it',
         'enabled': True,
         'order': 17
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/it_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/it_replay.py
@@ -30,37 +30,33 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'la7': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/it/la7:list_days',
         'label': 'La7',
         'thumb': 'channels/it/la7.png',
         'fanart': 'channels/it/la7_fanart.jpg',
-        'module': 'resources.lib.channels.it.la7',
         'enabled': True,
         'order': 1
     },
     'la7d': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/it/la7:list_days',
         'label': 'La7d',
         'thumb': 'channels/it/la7d.png',
         'fanart': 'channels/it/la7d_fanart.jpg',
-        'module': 'resources.lib.channels.it.la7',
         'enabled': True,
         'order': 15
     },
     'raiplay': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/it/raiplay:list_letters',
         'label': 'Rai Play',
         'thumb': 'channels/it/raiplay.png',
         'fanart': 'channels/it/raiplay_fanart.jpg',
-        'module': 'resources.lib.channels.it.raiplay',
         'enabled': True,
         'order': 16
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/jp_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/jp_live.py
@@ -30,37 +30,33 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'ntvnews24': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/jp/ntvnews24:get_live_url',
         'label': '日テレ News24',
         'thumb': 'channels/jp/ntvnews24.png',
         'fanart': 'channels/jp/ntvnews24_fanart.jpg',
-        'module': 'resources.lib.channels.jp.ntvnews24',
         'enabled': True,
         'order': 11
     },
     'japanetshoppingdx': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/jp/japanetshoppingdx:get_live_url',
         'label': 'ジャパネットチャンネルDX',
         'thumb': 'channels/jp/japanetshoppingdx.png',
         'fanart': 'channels/jp/japanetshoppingdx_fanart.jpg',
-        'module': 'resources.lib.channels.jp.japanetshoppingdx',
         'enabled': True,
         'order': 12
     },
     'weathernewsjp': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/jp/weathernewsjp:get_live_url',
         'label': '株式会社ウェザーニューズ',
         'thumb': 'channels/jp/weathernewsjp.png',
         'fanart': 'channels/jp/weathernewsjp_fanart.jpg',
-        'module': 'resources.lib.channels.jp.weathernewsjp',
         'enabled': True,
         'order': 14
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/jp_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/jp_replay.py
@@ -30,127 +30,113 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'nhknews': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/nhknews:list_categories',
         'label': 'NHK ニュース',
         'thumb': 'channels/jp/nhknews.png',
         'fanart': 'channels/jp/nhknews_fanart.jpg',
-        'module': 'resources.lib.channels.jp.nhknews',
         'enabled': True,
         'order': 1
     },
     'nhklifestyle': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/nhklifestyle:list_categories',
         'label': 'NHKらいふ',
         'thumb': 'channels/jp/nhklifestyle.png',
         'fanart': 'channels/jp/nhklifestyle_fanart.jpg',
-        'module': 'resources.lib.channels.jp.nhklifestyle',
         'enabled': True,
         'order': 2
     },
     'tbsnews': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tbsnews:list_categories',
         'label': 'TBS ニュース',
         'thumb': 'channels/jp/tbsnews.png',
         'fanart': 'channels/jp/tbsnews_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tbsnews',
         'enabled': True,
         'order': 3
     },
     'ex': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': 'テレビ朝日',
         'thumb': 'channels/jp/ex.png',
         'fanart': 'channels/jp/ex_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 5
     },
     'tbs': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': 'TBSテレビ',
         'thumb': 'channels/jp/tbs.png',
         'fanart': 'channels/jp/tbs_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 6
     },
     'tx': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': 'テレビ東京',
         'thumb': 'channels/jp/tx.png',
         'fanart': 'channels/jp/tx_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 7
     },
     'mbs': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': 'MBSテレビ',
         'thumb': 'channels/jp/mbs.png',
         'fanart': 'channels/jp/mbs_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 8
     },
     'abc': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': '朝日放送株式会社',
         'thumb': 'channels/jp/abc.png',
         'fanart': 'channels/jp/abc_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 9
     },
     'ytv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': '読売テレビ',
         'thumb': 'channels/jp/ytv.png',
         'fanart': 'channels/jp/ytv_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 10
     },
     'ntv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': '日テレ',
         'thumb': 'channels/jp/ntv.png',
         'fanart': 'channels/jp/ntv_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 11
     },
     'ktv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': '関西テレビ',
         'thumb': 'channels/jp/ktv.png',
         'fanart': 'channels/jp/ktv_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 13
     },
     'tvo': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': 'テレビ大阪株式会社',
         'thumb': 'channels/jp/tvo.png',
         'fanart': 'channels/jp/tvo_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 15
     },
     'nhk': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/jp/tver:list_categories',
         'label': 'NHK',
         'thumb': 'channels/jp/nhk.png',
         'fanart': 'channels/jp/nhk_fanart.jpg',
-        'module': 'resources.lib.channels.jp.tver',
         'enabled': True,
         'order': 16
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/live_tv.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/live_tv.py
@@ -30,133 +30,132 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 TV_GUIDE = Script.setting.get_boolean('tv_guide')
 
 menu = {
     'fr_live': {
-        'callback': 'tv_guide_menu'
-        if TV_GUIDE else 'generic_menu',
+        'route': '/resources/lib/main:tv_guide_menu'
+        if TV_GUIDE else '/resources/lib/main:generic_menu',
         'label': 30050,
         'thumb': 'channels/fr.png',
         'enabled': True,
         'order': 1
     },
     'ch_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30051,
         'thumb': 'channels/ch.png',
         'enabled': True,
         'order': 2
     },
     'uk_live': {
-        'callback': 'tv_guide_menu'
-        if TV_GUIDE else 'generic_menu',
+        'route': '/resources/lib/main:tv_guide_menu'
+        if TV_GUIDE else '/resources/lib/main:generic_menu',
         'label': 30052,
         'thumb': 'channels/uk.png',
         'enabled': True,
         'order': 3
     },
     'wo_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30053,
         'thumb': 'channels/wo.png',
         'enabled': True,
         'order': 4
     },
     'be_live': {
-        'callback': 'tv_guide_menu'
-        if TV_GUIDE else 'generic_menu',
+        'route': '/resources/lib/main:tv_guide_menu'
+        if TV_GUIDE else '/resources/lib/main:generic_menu',
         'label': 30054,
         'thumb': 'channels/be.png',
         'enabled': True,
         'order': 5
     },
     'jp_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30055,
         'thumb': 'channels/jp.png',
         'enabled': True,
         'order': 6
     },
     'ca_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30056,
         'thumb': 'channels/ca.png',
         'enabled': True,
         'order': 7
     },
     'us_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30057,
         'thumb': 'channels/us.png',
         'enabled': True,
         'order': 8
     },
     'pl_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30058,
         'thumb': 'channels/pl.png',
         'enabled': True,
         'order': 9
     },
     'es_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30059,
         'thumb': 'channels/es.png',
         'enabled': True,
         'order': 10
     },
     'tn_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30060,
         'thumb': 'channels/tn.png',
         'enabled': True,
         'order': 11
     },
     'it_live': {
-        'callback': 'tv_guide_menu'
-        if TV_GUIDE else 'generic_menu',
+        'route': '/resources/lib/main:tv_guide_menu'
+        if TV_GUIDE else '/resources/lib/main:generic_menu',
         'label': 30061,
         'thumb': 'channels/it.png',
         'enabled': True,
         'order': 12
     },
     'nl_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30062,
         'thumb': 'channels/nl.png',
         'enabled': True,
         'order': 13
     },
     'cn_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30063,
         'thumb': 'channels/cn.png',
         'enabled': True,
         'order': 14
     },
     'cm_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30064,
         'thumb': 'channels/cm.png',
         'enabled': True,
         'order': 15
     },
     'si_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30065,
         'thumb': 'channels/si.png',
         'enabled': True,
         'order': 16
     },
     'et_live': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30066,
         'thumb': 'channels/et.png',
         'enabled': True,

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/nl_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/nl_live.py
@@ -30,91 +30,81 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'npo-1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO 1',
         'thumb': 'channels/nl/npo1.png',
         'fanart': 'channels/nl/npo1_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 1
     },
     'npo-2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO 2',
         'thumb': 'channels/nl/npo2.png',
         'fanart': 'channels/nl/npo2_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 2
     },
     'npo-3zapp': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO 3',
         'thumb': 'channels/nl/npozapp.png',
         'fanart': 'channels/nl/npozapp_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 3
     },
     'npo-1-extra': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO 1 Extra',
         'thumb': 'channels/nl/npo1extra.png',
         'fanart': 'channels/nl/npo1extra_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 4
     },
     'npo-2-extra': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO 2 Extra',
         'thumb': 'channels/nl/npo2extra.png',
         'fanart': 'channels/nl/npo2extra_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 5
     },
     'npo-zappelin-extra': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO Zappelin Extra',
         'thumb': 'channels/nl/npozappelinextra.png',
         'fanart': 'channels/nl/npozappelinextra_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 6
     },
     'npo-nieuws': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO Nieuws',
         'thumb': 'channels/nl/nponieuws.png',
         'fanart': 'channels/nl/nponieuws_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 7
     },
     'npo-politiek': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/npo:get_live_url',
         'label': 'NPO Politiek',
         'thumb': 'channels/nl/npopolitiek.png',
         'fanart': 'channels/nl/npopolitiek_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 8
     },
     'at5': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/nl/at5:get_live_url',
         'label': 'AT5',
         'thumb': 'channels/nl/at5.png',
         'fanart': 'channels/nl/at5_fanart.jpg',
-        'module': 'resources.lib.channels.nl.at5',
         'enabled': True,
         'order': 10
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/nl_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/nl_replay.py
@@ -30,28 +30,25 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'npo-start': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/nl/npo:list_categories',
         'label': 'NPO Start',
         'thumb': 'channels/nl/npostart.png',
         'fanart': 'channels/nl/npostart_fanart.jpg',
-        'module': 'resources.lib.channels.nl.npo',
         'enabled': True,
         'order': 9
     },
     'at5': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/nl/at5:list_categories',
         'label': 'AT5',
         'thumb': 'channels/nl/at5.png',
         'fanart': 'channels/nl/at5_fanart.jpg',
-        'module': 'resources.lib.channels.nl.at5',
         'enabled': True,
         'order': 10
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/pl_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/pl_live.py
@@ -30,23 +30,19 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'tvp3': {
-        'callback':
-        'live_bridge',
+        'resolver': '/resources/lib/channels/pl/tvp:get_live_url',
         'label': 'TVP 3 (' + utils.ensure_unicode(Script.setting['tvp3.language']) + ')',
         'thumb':
         'channels/pl/tvp3.png',
         'fanart':
         'channels/pl/tvp3_fanart.jpg',
-        'module':
-        'resources.lib.channels.pl.tvp',
         'available_languages': [
             "Białystok", "Bydgoszcz", "Gdańsk", "Gorzów Wielkopolski",
             "Katowice", "Kielce", "Kraków", "Lublin", "Łódź", "Olsztyn",
@@ -56,29 +52,26 @@ menu = {
         'order': 2
     },
     'tvpinfo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/pl/tvp:get_live_url',
         'label': 'TVP Info',
         'thumb': 'channels/pl/tvpinfo.png',
         'fanart': 'channels/pl/tvpinfo_fanart.jpg',
-        'module': 'resources.lib.channels.pl.tvp',
         'enabled': True,
         'order': 3
     },
     'tvppolonia': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/pl/tvp:get_live_url',
         'label': 'TVP Polonia',
         'thumb': 'channels/pl/tvppolonia.png',
         'fanart': 'channels/pl/tvppolonia_fanart.jpg',
-        'module': 'resources.lib.channels.pl.tvp',
         'enabled': True,
         'order': 4
     },
     'tvppolandin': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/pl/tvp:get_live_url',
         'label': 'TVP Poland IN',
         'thumb': 'channels/pl/tvppolandin.png',
         'fanart': 'channels/pl/tvppolandin_fanart.jpg',
-        'module': 'resources.lib.channels.pl.tvp',
         'enabled': True,
         'order': 5
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/replay.py
@@ -29,113 +29,112 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'fr_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30050,
         'thumb': 'channels/fr.png',
         'enabled': True,
         'order': 1
     },
     'ch_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30051,
         'thumb': 'channels/ch.png',
         'enabled': True,
         'order': 2
     },
     'uk_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30052,
         'thumb': 'channels/uk.png',
         'enabled': True,
         'order': 3
     },
     'wo_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30053,
         'thumb': 'channels/wo.png',
         'enabled': True,
         'order': 4
     },
     'be_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30054,
         'thumb': 'channels/be.png',
         'enabled': True,
         'order': 5
     },
     'jp_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30055,
         'thumb': 'channels/jp.png',
         'enabled': True,
         'order': 6
     },
     'ca_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30056,
         'thumb': 'channels/ca.png',
         'enabled': True,
         'order': 7
     },
     'us_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30057,
         'thumb': 'channels/us.png',
         'enabled': True,
         'order': 8
     },
     'pl_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30058,
         'thumb': 'channels/us.png',
         'enabled': False,
         'order': 9
     },
     'es_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30059,
         'thumb': 'channels/es.png',
         'enabled': False,
         'order': 10
     },
     'tn_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30060,
         'thumb': 'channels/tn.png',
         'enabled': True,
         'order': 11
     },
     'it_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30061,
         'thumb': 'channels/it.png',
         'enabled': True,
         'order': 12
     },
     'nl_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30062,
         'thumb': 'channels/nl.png',
         'enabled': True,
         'order': 13
     },
     'cn_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30063,
         'thumb': 'channels/nl.png',
         'enabled': False,
         'order': 14
     },
     'cm_replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30064,
         'thumb': 'channels/cm.png',
         'enabled': False,

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/root.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/root.py
@@ -29,36 +29,35 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'live_tv': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30030,
         'thumb': 'live_tv.png',
         'enabled': True,
         'order': 1
     },
     'replay': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30031,
         'thumb': 'replay.png',
         'enabled': True,
         'order': 2
     },
     'websites': {
-        'callback': 'generic_menu',
+        'route': '/resources/lib/main:generic_menu',
         'label': 30032,
         'thumb': 'websites.png',
         'enabled': True,
         'order': 3
     },
     'favourites': {
-        'callback': 'favourites',
+        'route': '/resources/lib/main:favourites',
         'label': 30033,
         'thumb': 'favourites.png',
         'enabled': True,

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/si_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/si_live.py
@@ -30,64 +30,57 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'slo1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/si/rtvslo:get_live_url',
         'label': 'TV SLO 1',
         'thumb': 'channels/si/slo1.png',
         'fanart': 'channels/si/slo1_fanart.jpg',
-        'module': 'resources.lib.channels.si.rtvslo',
         'enabled': True,
         'order': 1
     },
     'slo2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/si/rtvslo:get_live_url',
         'label': 'TV SLO 2',
         'thumb': 'channels/si/slo2.png',
         'fanart': 'channels/si/slo2_fanart.jpg',
-        'module': 'resources.lib.channels.si.rtvslo',
         'enabled': True,
         'order': 2
     },
     'slo3': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/si/rtvslo:get_live_url',
         'label': 'TV SLO 3',
         'thumb': 'channels/si/slo3.png',
         'fanart': 'channels/si/slo3_fanart.jpg',
-        'module': 'resources.lib.channels.si.rtvslo',
         'enabled': True,
         'order': 3
     },
     'koper': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/si/rtvslo:get_live_url',
         'label': 'Koper',
         'thumb': 'channels/si/koper.png',
         'fanart': 'channels/si/koper_fanart.jpg',
-        'module': 'resources.lib.channels.si.rtvslo',
         'enabled': True,
         'order': 4
     },
     'maribor': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/si/rtvslo:get_live_url',
         'label': 'Maribor',
         'thumb': 'channels/si/maribor.png',
         'fanart': 'channels/si/maribor_fanart.jpg',
-        'module': 'resources.lib.channels.si.rtvslo',
         'enabled': True,
         'order': 5
     },
     'mmc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/si/rtvslo:get_live_url',
         'label': 'MMC',
         'thumb': 'channels/si/mmc.png',
         'fanart': 'channels/si/mmc_fanart.jpg',
-        'module': 'resources.lib.channels.si.rtvslo',
         'enabled': True,
         'order': 6
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/tn_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/tn_live.py
@@ -30,37 +30,33 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'watania1': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/tn/watania:get_live_url',
         'label': 'التلفزة التونسية الوطنية 1',
         'thumb': 'channels/tn/watania1.png',
         'fanart': 'channels/tn/watania1_fanart.jpg',
-        'module': 'resources.lib.channels.tn.watania',
         'enabled': True,
         'order': 1
     },
     'watania2': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/tn/watania:get_live_url',
         'label': 'التلفزة التونسية الوطنية 2',
         'thumb': 'channels/tn/watania2.png',
         'fanart': 'channels/tn/watania2_fanart.jpg',
-        'module': 'resources.lib.channels.tn.watania',
         'enabled': True,
         'order': 2
     },
     'nessma': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/tn/nessma:get_live_url',
         'label': 'نسمة تي في',
         'thumb': 'channels/tn/nessma.png',
         'fanart': 'channels/tn/nessma_fanart.jpg',
-        'module': 'resources.lib.channels.tn.nessma',
         'enabled': True,
         'order': 3
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/tn_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/tn_replay.py
@@ -30,19 +30,17 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'nessma': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/tn/nessma:list_categories',
         'label': 'نسمة تي في',
         'thumb': 'channels/tn/nessma.png',
         'fanart': 'channels/tn/nessma_fanart.jpg',
-        'module': 'resources.lib.channels.tn.nessma',
         'enabled': True,
         'order': 3
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/uk_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/uk_live.py
@@ -30,221 +30,198 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'blaze': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/blaze:get_live_url',
         'label': 'Blaze',
         'thumb': 'channels/uk/blaze.png',
         'fanart': 'channels/uk/blaze_fanart.jpg',
-        'module': 'resources.lib.channels.uk.blaze',
         'xmltv_id': '1013.tvguide.co.uk',
         'enabled': True,
         'order': 1
     },
     'dave': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/uktvplay:get_live_url',
         'label': 'Dave',
         'thumb': 'channels/uk/dave.png',
         'fanart': 'channels/uk/dave_fanart.jpg',
-        'module': 'resources.lib.channels.uk.uktvplay',
         'xmltv_id': '432.tvguide.co.uk',
         'enabled': True,
         'order': 2
     },
     'yesterday': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/uktvplay:get_live_url',
         'label': 'Yesterday',
         'thumb': 'channels/uk/yesterday.png',
         'fanart': 'channels/uk/yesterday_fanart.jpg',
-        'module': 'resources.lib.channels.uk.uktvplay',
         'xmltv_id': '320.tvguide.co.uk',
         'enabled': True,
         'order': 4
     },
     'drama': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/uktvplay:get_live_url',
         'label': 'Drama',
         'thumb': 'channels/uk/drama.png',
         'fanart': 'channels/uk/drama_fanart.jpg',
-        'module': 'resources.lib.channels.uk.uktvplay',
         'xmltv_id': '871.tvguide.co.uk',
         'enabled': True,
         'order': 5
     },
     'skynews': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/sky:get_live_url',
         'label': 'Sky News',
         'thumb': 'channels/uk/skynews.png',
         'fanart': 'channels/uk/skynews_fanart.jpg',
-        'module': 'resources.lib.channels.uk.sky',
         'xmltv_id': '257.tvguide.co.uk',
         'enabled': True,
         'order': 6
     },
     'stv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'STV',
         'thumb': 'channels/uk/stv.png',
         'fanart': 'channels/uk/stv_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'xmltv_id': '178.tvguide.co.uk',
         'enabled': True,
         'order': 8
     },
     'kerrang': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/boxplus:get_live_url',
         'label': 'Kerrang',
         'thumb': 'channels/uk/kerrang.png',
         'fanart': 'channels/uk/kerrang_fanart.jpg',
-        'module': 'resources.lib.channels.uk.boxplus',
         'xmltv_id': '1207.tvguide.co.uk',
         'enabled': True,
         'order': 11
     },
     'magic': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/boxplus:get_live_url',
         'label': 'Magic',
         'thumb': 'channels/uk/magic.png',
         'fanart': 'channels/uk/magic_fanart.jpg',
-        'module': 'resources.lib.channels.uk.boxplus',
         'xmltv_id': '185.tvguide.co.uk',
         'enabled': True,
         'order': 12
     },
     'kiss': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/boxplus:get_live_url',
         'label': 'Kiss',
         'thumb': 'channels/uk/kiss.png',
         'fanart': 'channels/uk/kiss_fanart.jpg',
-        'module': 'resources.lib.channels.uk.boxplus',
         'xmltv_id': '182.tvguide.co.uk',
         'enabled': True,
         'order': 13
     },
     'the-box': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/boxplus:get_live_url',
         'label': 'The Box',
         'thumb': 'channels/uk/thebox.png',
         'fanart': 'channels/uk/thebox_fanart.jpg',
-        'module': 'resources.lib.channels.uk.boxplus',
         'xmltv_id': '279.tvguide.co.uk',
         'enabled': True,
         'order': 14
     },
     'box-hits': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/boxplus:get_live_url',
         'label': 'Box Hits',
         'thumb': 'channels/uk/boxhits.png',
         'fanart': 'channels/uk/boxhits_fanart.jpg',
-        'module': 'resources.lib.channels.uk.boxplus',
         'xmltv_id': '267.tvguide.co.uk',
         'enabled': True,
         'order': 15
     },
     'box-upfront': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/boxplus:get_live_url',
         'label': 'Box Upfront',
         'thumb': 'channels/uk/boxupfront.png',
         'fanart': 'channels/uk/boxupfront_fanart.jpg',
-        'module': 'resources.lib.channels.uk.boxplus',
         'enabled': True,
         'order': 16
     },
     'questtv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/questod:get_live_url',
         'label': 'Quest TV',
         'thumb': 'channels/uk/questtv.png',
         'fanart': 'channels/uk/questtv_fanart.jpg',
-        'module': 'resources.lib.channels.uk.questod',
         'xmltv_id': '1230.tvguide.co.uk',
         'enabled': True,
         'order': 18
     },
     'questred': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/questod:get_live_url',
         'label': 'Quest RED',
         'thumb': 'channels/uk/questred.png',
         'fanart': 'channels/uk/questred_fanart.jpg',
-        'module': 'resources.lib.channels.uk.questod',
         'xmltv_id': '1014.tvguide.co.uk',
         'enabled': True,
         'order': 19
     },
     'bristoltv': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/bristoltv:get_live_url',
         'label': 'Bristol TV',
         'thumb': 'channels/uk/bristoltv.png',
         'fanart': 'channels/uk/bristoltv_fanart.jpg',
-        'module': 'resources.lib.channels.uk.bristoltv',
         'enabled': True,
         'order': 21
     },
     'freesports': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'Free Sports',
         'thumb': 'channels/uk/freesports.png',
         'fanart': 'channels/uk/freesports_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 23
     },
     'stv_plusone': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'STV+1',
         'thumb': 'channels/uk/stv_plusone.png',
         'fanart': 'channels/uk/stv_plusone_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 24
     },
     'edgesport': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'EDGE Sport',
         'thumb': 'channels/uk/edgesport.png',
         'fanart': 'channels/uk/edgesport_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 25
     },
     'thepetcollective': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'The Pet Collective',
         'thumb': 'channels/uk/thepetcollective.png',
         'fanart': 'channels/uk/thepetcollective_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 27
     },
     'failarmy': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'Fail Army',
         'thumb': 'channels/uk/failarmy.png',
         'fanart': 'channels/uk/failarmy_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 28
     },
     'qello': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'Qello',
         'thumb': 'channels/uk/qello.png',
         'fanart': 'channels/uk/qello_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 29
     },
     'dust': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'DUST',
         'thumb': 'channels/uk/dust.png',
         'fanart': 'channels/uk/dust_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 30
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/uk_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/uk_replay.py
@@ -30,82 +30,73 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'blaze': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/blaze:list_categories',
         'label': 'Blaze',
         'thumb': 'channels/uk/blaze.png',
         'fanart': 'channels/uk/blaze_fanart.jpg',
-        'module': 'resources.lib.channels.uk.blaze',
         'enabled': True,
         'order': 1
     },
     'skynews': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/sky:list_categories',
         'label': 'Sky News',
         'thumb': 'channels/uk/skynews.png',
         'fanart': 'channels/uk/skynews_fanart.jpg',
-        'module': 'resources.lib.channels.uk.sky',
         'enabled': True,
         'order': 6
     },
     'skysports': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/sky:list_categories',
         'label': 'Sky Sports',
         'thumb': 'channels/uk/skysports.png',
         'fanart': 'channels/uk/skysports_fanart.jpg',
-        'module': 'resources.lib.channels.uk.sky',
         'enabled': True,
         'order': 7
     },
     'stv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/stv:list_categories',
         'label': 'STV',
         'thumb': 'channels/uk/stv.png',
         'fanart': 'channels/uk/stv_fanart.jpg',
-        'module': 'resources.lib.channels.uk.stv',
         'enabled': True,
         'order': 8
     },
     'questod': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/questod:list_categories',
         'label': 'Quest OD',
         'thumb': 'channels/uk/questod.png',
         'fanart': 'channels/uk/questod_fanart.jpg',
-        'module': 'resources.lib.channels.uk.questod',
         'enabled': True,
         'order': 9
     },
     'uktvplay': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/uktvplay:list_categories',
         'label': 'UKTV Play',
         'thumb': 'channels/uk/uktvplay.png',
         'fanart': 'channels/uk/uktvplay_fanart.jpg',
-        'module': 'resources.lib.channels.uk.uktvplay',
         'enabled': True,
         'order': 17
     },
     'fiveusa': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/my5:list_programs',
         'label': '5USA',
         'thumb': 'channels/uk/fiveusa.png',
         'fanart': 'channels/uk/fiveusa_fanart.jpg',
-        'module': 'resources.lib.channels.uk.my5',
         'enabled': False,
         'order': 20
     },
     'bristoltv': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/uk/bristoltv:list_categories',
         'label': 'Bristol TV',
         'thumb': 'channels/uk/bristoltv.png',
         'fanart': 'channels/uk/bristoltv_fanart.jpg',
-        'module': 'resources.lib.channels.uk.bristoltv',
         'enabled': True,
         'order': 21
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/us_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/us_live.py
@@ -30,46 +30,41 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'cbsnews': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/us/cbsnews:get_live_url',
         'label': 'CBS News',
         'thumb': 'channels/us/cbsnews.png',
         'fanart': 'channels/us/cbsnews_fanart.jpg',
-        'module': 'resources.lib.channels.us.cbsnews',
         'enabled': True,
         'order': 1
     },
     'tbd': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/us/tbd:get_live_url',
         'label': 'TBD',
         'thumb': 'channels/us/tbd.png',
         'fanart': 'channels/us/tbd_fanart.jpg',
-        'module': 'resources.lib.channels.us.tbd',
         'enabled': True,
         'order': 2
     },
     'abcnews': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/us/abcnews:get_live_url',
         'label': 'ABC News',
         'thumb': 'channels/us/abcnews.png',
         'fanart': 'channels/us/abcnews_fanart.jpg',
-        'module': 'resources.lib.channels.us.abcnews',
         'enabled': True,
         'order': 4
     },
     'pbskids': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/us/pbskids:get_live_url',
         'label': 'PBS Kids',
         'thumb': 'channels/us/pbskids.png',
         'fanart': 'channels/us/pbskids_fanart.jpg',
-        'module': 'resources.lib.channels.us.pbskids',
         'enabled': True,
         'order': 5
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/us_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/us_replay.py
@@ -30,37 +30,33 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'tbd': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/us/tbd:list_programs',
         'label': 'TBD',
         'thumb': 'channels/us/tbd.png',
         'fanart': 'channels/us/tbd_fanart.jpg',
-        'module': 'resources.lib.channels.us.tbd',
         'enabled': True,
         'order': 2
     },
     'nycmedia': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/us/nycmedia:list_programs',
         'label': 'NYC Media',
         'thumb': 'channels/us/nycmedia.png',
         'fanart': 'channels/us/nycmedia_fanart.jpg',
-        'module': 'resources.lib.channels.us.nycmedia',
         'enabled': True,
         'order': 3
     },
     'abcnews': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/us/abcnews:list_programs',
         'label': 'ABC News',
         'thumb': 'channels/us/abcnews.png',
         'fanart': 'channels/us/abcnews_fanart.jpg',
-        'module': 'resources.lib.channels.us.abcnews',
         'enabled': True,
         'order': 4
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/websites.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/websites.py
@@ -30,172 +30,153 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'allocine': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/allocine:website_root',
         'label': 'Allociné',
         'thumb': 'websites/allocine.png',
         'fanart': 'websites/allocine_fanart.jpg',
-        'module': 'resources.lib.websites.allocine',
         'enabled': True,
         'order': 1
     },
     'tetesaclaques': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/tetesaclaques:website_root',
         'label': 'Au pays des Têtes à claques',
         'thumb': 'websites/tetesaclaques.png',
         'fanart': 'websites/tetesaclaques_fanart.jpg',
-        'module': 'resources.lib.websites.tetesaclaques',
         'enabled': True,
         'order': 2
     },
     'taratata': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/taratata:website_root',
         'label': 'Taratata',
         'thumb': 'websites/taratata.png',
         'fanart': 'websites/taratata_fanart.jpg',
-        'module': 'resources.lib.websites.taratata',
         'enabled': True,
         'order': 3
     },
     'noob': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/noob:website_root',
         'label': 'Noob TV',
         'thumb': 'websites/noob.png',
         'fanart': 'websites/noob_fanart.jpg',
-        'module': 'resources.lib.websites.noob',
         'enabled': True,
         'order': 4
     },
     'culturepub': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/culturepub:website_root',
         'label': 'Culturepub',
         'thumb': 'websites/culturepub.png',
         'fanart': 'websites/culturepub_fanart.jpg',
-        'module': 'resources.lib.websites.culturepub',
         'enabled': True,
         'order': 5
     },
     'autoplus': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/autoplus:website_root',
         'label': 'Auto Plus',
         'thumb': 'websites/autoplus.png',
         'fanart': 'websites/autoplus_fanart.jpg',
-        'module': 'resources.lib.websites.autoplus',
         'enabled': True,
         'order': 6
     },
     'notrehistoirech': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/notrehistoirech:website_root',
         'label': 'Notre Histoire',
         'thumb': 'websites/notrehistoirech.png',
         'fanart': 'websites/notrehistoirech_fanart.jpg',
-        'module': 'resources.lib.websites.notrehistoirech',
         'enabled': True,
         'order': 7
     },
     '30millionsdamis': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/30millionsdamis:website_root',
         'label': '30 Millions d\'Amis',
         'thumb': 'websites/30millionsdamis.png',
         'fanart': 'websites/30millionsdamis_fanart.jpg',
-        'module': 'resources.lib.websites.30millionsdamis',
         'enabled': True,
         'order': 8
     },
     'elle': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/elle:website_root',
         'label': 'Elle',
         'thumb': 'websites/elle.png',
         'fanart': 'websites/elle_fanart.jpg',
-        'module': 'resources.lib.websites.elle',
         'enabled': True,
         'order': 9
     },
     'nytimes': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/nytimes:website_root',
         'label': 'New York Times',
         'thumb': 'websites/nytimes.png',
         'fanart': 'websites/nytimes_fanart.jpg',
-        'module': 'resources.lib.websites.nytimes',
         'enabled': True,
         'order': 10
     },
     'fosdem': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/fosdem:website_root',
         'label': 'Fosdem',
         'thumb': 'websites/fosdem.png',
         'fanart': 'websites/fosdem_fanart.jpg',
-        'module': 'resources.lib.websites.fosdem',
         'enabled': True,
         'order': 11
     },
     'ina': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/ina:website_root',
         'label': 'Ina',
         'thumb': 'websites/ina.png',
         'fanart': 'websites/ina_fanart.jpg',
-        'module': 'resources.lib.websites.ina',
         'enabled': True,
         'order': 12
     },
     'onf': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/onf:website_root',
         'label': 'Office National du Film du Canada',
         'thumb': 'websites/onf.png',
         'fanart': 'websites/onf_fanart.jpg',
-        'module': 'resources.lib.websites.onf',
         'enabled': True,
         'order': 13
     },
     'nfb': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/nfb:website_root',
         'label': 'National Film Board Of Canada',
         'thumb': 'websites/nfb.png',
         'fanart': 'websites/nfb_fanart.jpg',
-        'module': 'resources.lib.websites.nfb',
         'enabled': True,
         'order': 14
     },
     'marmiton': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/marmiton:website_root',
         'label': 'Marmiton',
         'thumb': 'websites/marmiton.png',
         'fanart': 'websites/marmiton_fanart.jpg',
-        'module': 'resources.lib.websites.marmiton',
         'enabled': True,
         'order': 15
     },
     'lesargonautes': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/lesargonautes:website_root',
         'label': 'Les Argonautes',
         'thumb': 'websites/lesargonautes.png',
         'fanart': 'websites/lesargonautes_fanart.jpg',
-        'module': 'resources.lib.websites.lesargonautes',
         'enabled': True,
         'order': 16
     },
     'nationalfff': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/nationalfff:website_root',
         'label': 'National FFF',
         'thumb': 'websites/nationalfff.png',
         'fanart': 'websites/nationalfff_fanart.jpg',
-        'module': 'resources.lib.websites.nationalfff',
         'enabled': True,
         'order': 17
     },
     'philharmoniedeparis': {
-        'callback': 'website_bridge',
+        'route': '/resources/lib/websites/philharmoniedeparis:website_root',
         'label': 'Philharmonie de Paris',
         'thumb': 'websites/philharmoniedeparis.png',
         'fanart': 'websites/philharmoniedeparis_fanart.jpg',
-        'module': 'resources.lib.websites.philharmoniedeparis',
         'enabled': True,
         'order': 18
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/wo_live.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/wo_live.py
@@ -30,23 +30,19 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'euronews': {
-        'callback':
-        'live_bridge',
+        'resolver': '/resources/lib/channels/wo/euronews:get_live_url',
         'label': 'Euronews (' + utils.ensure_unicode(Script.setting['euronews.language']) + ')',
         'thumb':
         'channels/wo/euronews.png',
         'fanart':
         'channels/wo/euronews_fanart.jpg',
-        'module':
-        'resources.lib.channels.wo.euronews',
         'available_languages': [
             'FR', 'EN', 'AR', 'DE', 'IT', 'ES', 'PT', 'RU', 'TR', 'FA', 'GR',
             'HU'
@@ -55,11 +51,10 @@ menu = {
         'order': 2
     },
     'arte': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/arte:get_live_url',
         'label': 'Arte (' + utils.ensure_unicode(Script.setting['arte.language']) + ')',
         'thumb': 'channels/wo/arte.png',
         'fanart': 'channels/wo/arte_fanart.jpg',
-        'module': 'resources.lib.channels.wo.arte',
         'available_languages': ['FR', 'DE'],
         'xmltv_ids': {
             'FR': 'C111.api.telerama.fr'
@@ -74,161 +69,144 @@ menu = {
         'order': 3
     },
     'france24': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/france24:get_live_url',
         'label': 'France 24 (' + utils.ensure_unicode(Script.setting['france24.language']) + ')',
         'thumb': 'channels/wo/france24.png',
         'fanart': 'channels/wo/france24_fanart.jpg',
-        'module': 'resources.lib.channels.wo.france24',
         'available_languages': ['FR', 'EN', 'AR', 'ES'],
         'enabled': True,
         'order': 4
     },
     'nhkworld': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/nhkworld:get_live_url',
         'label': 'NHK World (' + utils.ensure_unicode(Script.setting['nhkworld.language']) + ')',
         'thumb': 'channels/wo/nhkworld.png',
         'fanart': 'channels/wo/nhkworld_fanart.jpg',
-        'module': 'resources.lib.channels.wo.nhkworld',
         'available_languages': ['Outside Japan', 'In Japan'],
         'enabled': True,
         'order': 5
     },
     'tivi5monde': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/tivi5monde:get_live_url',
         'label': 'Tivi 5Monde',
         'thumb': 'channels/wo/tivi5monde.png',
         'fanart': 'channels/wo/tivi5monde_fanart.jpg',
-        'module': 'resources.lib.channels.wo.tivi5monde',
         'enabled': True,
         'order': 7
     },
     'bvn': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/bvn:get_live_url',
         'label': 'BVN',
         'thumb': 'channels/wo/bvn.png',
         'fanart': 'channels/wo/bvn_fanart.jpg',
-        'module': 'resources.lib.channels.wo.bvn',
         'enabled': True,
         'order': 8
     },
     'icitelevision': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/icitelevision:get_live_url',
         'label': 'ICI Télévision',
         'thumb': 'channels/wo/icitelevision.png',
         'fanart': 'channels/wo/icitelevision_fanart.jpg',
-        'module': 'resources.lib.channels.wo.icitelevision',
         'enabled': True,
         'order': 9
     },
     'arirang': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/arirang:get_live_url',
         'label': 'Arirang (아리랑)',
         'thumb': 'channels/wo/arirang.png',
         'fanart': 'channels/wo/arirang_fanart.jpg',
-        'module': 'resources.lib.channels.wo.arirang',
         'enabled': True,
         'order': 11
     },
     'dw': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/dw:get_live_url',
         'label': 'DW (' + utils.ensure_unicode(Script.setting['dw.language']) + ')',
         'thumb': 'channels/wo/dw.png',
         'fanart': 'channels/wo/dw_fanart.jpg',
-        'module': 'resources.lib.channels.wo.dw',
         'available_languages': ['EN', 'AR', 'ES', 'DE'],
         'enabled': True,
         'order': 12
     },
     'qvc': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/qvc:get_live_url',
         'label': 'QVC (' + utils.ensure_unicode(Script.setting['qvc.language']) + ')',
         'thumb': 'channels/wo/qvc.png',
         'fanart': 'channels/wo/qvc_fanart.jpg',
-        'module': 'resources.lib.channels.wo.qvc',
         'available_languages': ['JP', 'DE', 'IT', 'UK', 'US'],
         'enabled': True,
         'order': 15
     },
     'icirdi': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/icirdi:get_live_url',
         'label': 'ICI RDI',
         'thumb': 'channels/wo/icirdi.png',
         'fanart': 'channels/wo/icirdi_fanart.jpg',
-        'module': 'resources.lib.channels.wo.icirdi',
         'enabled': True,
         'order': 16
     },
     'cgtn': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/cgtn:get_live_url',
         'label': 'CGTN (' + utils.ensure_unicode(Script.setting['cgtn.language']) + ')',
         'thumb': 'channels/wo/cgtn.png',
         'fanart': 'channels/wo/cgtn_fanart.jpg',
-        'module': 'resources.lib.channels.wo.cgtn',
         'available_languages': ['FR', 'EN', 'AR', 'ES', 'RU'],
         'enabled': True,
         'order': 17
     },
     'cgtndocumentary': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/cgtn:get_live_url',
         'label': 'CGTN Documentary',
         'thumb': 'channels/wo/cgtndocumentary.png',
         'fanart': 'channels/wo/cgtndocumentary_fanart.jpg',
-        'module': 'resources.lib.channels.wo.cgtn',
         'enabled': True,
         'order': 18
     },
     'afriquemedia': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/afriquemedia:get_live_url',
         'label': 'Afrique Media',
         'thumb': 'channels/wo/afriquemedia.png',
         'fanart': 'channels/wo/afriquemedia_fanart.jpg',
-        'module': 'resources.lib.channels.wo.afriquemedia',
         'enabled': True,
         'order': 20
     },
     'tv5mondefbs': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/tv5monde:get_live_url',
         'label': 'TV5Monde France Belgique Suisse',
         'thumb': 'channels/wo/tv5mondefbs.png',
         'fanart': 'channels/wo/tv5mondefbs_fanart.jpg',
-        'module': 'resources.lib.channels.wo.tv5monde',
         'enabled': True,
         'order': 21
     },
     'tv5mondeinfo': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/tv5monde:get_live_url',
         'label': 'TV5Monde Info',
         'thumb': 'channels/wo/tv5mondeinfo.png',
         'fanart': 'channels/wo/tv5mondeinfo_fanart.jpg',
-        'module': 'resources.lib.channels.wo.tv5monde',
         'enabled': True,
         'order': 22
     },
     'channelnewsasia': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/channelnewsasia:get_live_url',
         'label': 'Channel NewsAsia',
         'thumb': 'channels/wo/channelnewsasia.png',
         'fanart': 'channels/wo/channelnewsasia_fanart.jpg',
-        'module': 'resources.lib.channels.wo.channelnewsasia',
         'enabled': True,
         'order': 23
     },
     'rt': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/rt:get_live_url',
         'label': 'RT (' + utils.ensure_unicode(Script.setting['rt.language']) + ')',
         'thumb': 'channels/wo/rt.png',
         'fanart': 'channels/wo/rt_fanart.jpg',
-        'module': 'resources.lib.channels.wo.rt',
         'available_languages': ['FR', 'EN', 'AR', 'ES'],
         'enabled': True,
         'order': 24
     },
     'africa24': {
-        'callback': 'live_bridge',
+        'resolver': '/resources/lib/channels/wo/africa24:get_live_url',
         'label': 'Africa 24',
         'thumb': 'channels/wo/africa24.png',
         'fanart': 'channels/wo/africa24_fanart.jpg',
-        'module': 'resources.lib.channels.wo.africa24',
         'enabled': True,
         'order': 25
     }

--- a/plugin.video.catchuptvandmore/resources/lib/skeletons/wo_replay.py
+++ b/plugin.video.catchuptvandmore/resources/lib/skeletons/wo_replay.py
@@ -30,128 +30,114 @@ The following dictionaries describe
 the addon's tree architecture.
 * Key: item id
 * Value: item infos
-    - callback: Callback function to run once this item is selected
+    - route (folder)/resolver (playable URL): Callback function to run once this item is selected
     - thumb: Item thumb path relative to "media" folder
     - fanart: Item fanart path relative to "meia" folder
-    - module: Item module to load in order to work (like 6play.py)
 """
 
 menu = {
     'tv5mondeafrique': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/tv5mondeafrique:list_categories',
         'label': 'TV5Monde Afrique',
         'thumb': 'channels/wo/tv5mondeafrique.png',
         'fanart': 'channels/wo/tv5mondeafrique_fanart.jpg',
-        'module': 'resources.lib.channels.wo.tv5mondeafrique',
         'enabled': True,
         'order': 1
     },
     'arte': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/arte:list_categories',
         'label': 'Arte (' + utils.ensure_unicode(Script.setting['arte.language']) + ')',
         'thumb': 'channels/wo/arte.png',
         'fanart': 'channels/wo/arte_fanart.jpg',
-        'module': 'resources.lib.channels.wo.arte',
         'enabled': True,
         'order': 3
     },
     'france24': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/france24:root',
         'label': 'France 24 (' + utils.ensure_unicode(Script.setting['france24.language']) + ')',
         'thumb': 'channels/wo/france24.png',
         'fanart': 'channels/wo/france24_fanart.jpg',
-        'module': 'resources.lib.channels.wo.france24',
         'enabled': True,
         'order': 4
     },
     'nhkworld': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/nhkworld:list_categories',
         'label': 'NHK World (' + utils.ensure_unicode(Script.setting['nhkworld.language']) + ')',
         'thumb': 'channels/wo/nhkworld.png',
         'fanart': 'channels/wo/nhkworld_fanart.jpg',
-        'module': 'resources.lib.channels.wo.nhkworld',
         'enabled': True,
         'order': 5
     },
     'tv5monde': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/tv5monde:list_categories',
         'label': 'TV5Monde',
         'thumb': 'channels/wo/tv5monde.png',
         'fanart': 'channels/wo/tv5monde_fanart.jpg',
-        'module': 'resources.lib.channels.wo.tv5monde',
         'enabled': True,
         'order': 6
     },
     'tivi5monde': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/tivi5monde:list_categories',
         'label': 'Tivi 5Monde',
         'thumb': 'channels/wo/tivi5monde.png',
         'fanart': 'channels/wo/tivi5monde_fanart.jpg',
-        'module': 'resources.lib.channels.wo.tivi5monde',
         'enabled': True,
         'order': 7
     },
     'bvn': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/bvn:list_days',
         'label': 'BVN',
         'thumb': 'channels/wo/bvn.png',
         'fanart': 'channels/wo/bvn_fanart.jpg',
-        'module': 'resources.lib.channels.wo.bvn',
         'enabled': True,
         'order': 8
     },
     'arirang': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/arirang:list_categories',
         'label': 'Arirang (아리랑)',
         'thumb': 'channels/wo/arirang.png',
         'fanart': 'channels/wo/arirang_fanart.jpg',
-        'module': 'resources.lib.channels.wo.arirang',
         'enabled': True,
         'order': 11
     },
     'beinsports': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/beinsports:list_sites',
         'label': 'Bein Sports',
         'thumb': 'channels/wo/beinsports.png',
         'fanart': 'channels/wo/beinsports_fanart.jpg',
-        'module': 'resources.lib.channels.wo.beinsports',
         'enabled': True,
         'order': 13
     },
     'afriquemedia': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/afriquemedia:list_categories',
         'label': 'Afrique Media',
         'thumb': 'channels/wo/afriquemedia.png',
         'fanart': 'channels/wo/afriquemedia_fanart.jpg',
-        'module': 'resources.lib.channels.wo.afriquemedia',
         'enabled': True,
         'order': 20
     },
     'channelnewsasia': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/channelnewsasia:list_categories',
         'label': 'Channel NewsAsia',
         'thumb': 'channels/wo/channelnewsasia.png',
         'fanart': 'channels/wo/channelnewsasia_fanart.jpg',
-        'module': 'resources.lib.channels.wo.channelnewsasia',
         'enabled': True,
         'order': 23
     },
     'rt': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/rt:list_categories',
         'label': 'RT (' + utils.ensure_unicode(Script.setting['rt.language']) + ')',
         'thumb': 'channels/wo/rt.png',
         'fanart': 'channels/wo/rt_fanart.jpg',
-        'module': 'resources.lib.channels.wo.rt',
         'available_languages': ['FR', 'EN'],
         'enabled': True,
         'order': 24
     },
     'africa24': {
-        'callback': 'replay_bridge',
+        'route': '/resources/lib/channels/wo/africa24:list_categories',
         'label': 'Africa 24',
         'thumb': 'channels/wo/africa24.png',
         'fanart': 'channels/wo/africa24_fanart.jpg',
-        'module': 'resources.lib.channels.wo.africa24',
         'enabled': True,
         'order': 25
     }

--- a/plugin.video.catchuptvandmore/resources/lib/websites/30millionsdamis.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/30millionsdamis.py
@@ -33,14 +33,8 @@ import urlquick
 URL_ROOT = 'http://www.30millionsdamis.fr'
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_ROOT + '/actualites/videos')
     root = resp.parse("select", attrs={"class": "selecttourl"})

--- a/plugin.video.catchuptvandmore/resources/lib/websites/allocine.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/allocine.py
@@ -51,13 +51,6 @@ URL_SEARCH_VIDEOS = URL_ROOT + '/recherche/18/?p=%s&q=%s'
 # Page, Query
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
 CATEGORIES = {
     'Les émissions': URL_ROOT + '/video/',
     'Videos Films (Bandes-Annonces, Extraits, ...)':
@@ -70,7 +63,8 @@ CATEGORIES = {
 CATEGORIES_LANGUAGE = {'VF': 'version-0/', 'VO': 'version-1/'}
 
 
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     for category_name, category_url in list(CATEGORIES.items()):
 

--- a/plugin.video.catchuptvandmore/resources/lib/websites/autoplus.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/autoplus.py
@@ -35,14 +35,8 @@ from resources.lib.menu_utils import item_post_treatment
 URL_ROOT = 'https://www.autoplus.fr/video/'
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     item = Listitem()
     item.label = plugin.localize(30701)

--- a/plugin.video.catchuptvandmore/resources/lib/websites/culturepub.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/culturepub.py
@@ -44,14 +44,8 @@ INFO_STREAM = 'http://cbnews.ondemand.flumotion.com/video/mp4/%s/%s.mp4'
 QUALITIES_STREAM = ['low', 'hd']
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
 
     resp = urlquick.get(URL_ROOT)

--- a/plugin.video.catchuptvandmore/resources/lib/websites/elle.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/elle.py
@@ -41,14 +41,8 @@ URL_VIDEOS_JSON = 'https://content.jwplatform.com/v2/playlists/%s'
 # CategoryId
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     categories_html = urlquick.get(URL_CATEGORIES).text
     categories_js_id = re.compile(

--- a/plugin.video.catchuptvandmore/resources/lib/websites/fosdem.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/fosdem.py
@@ -40,14 +40,8 @@ BEGINING_YEAR_XML = 2012
 LAST_YEAR_XML = 2020
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     for i in range(BEGINING_YEAR_XML, LAST_YEAR_XML + 1):
         item = Listitem()

--- a/plugin.video.catchuptvandmore/resources/lib/websites/ina.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/ina.py
@@ -45,14 +45,8 @@ URL_STREAM = 'https://player.ina.fr/notices/%s'
 # VideoId
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin)
-
-
-def root(plugin, **kwargs):
+@Route.register
+def website_root(plugin, **kwargs):
     """Build root listing"""
     categories = [
         ('Thèmes', list_subcategories, 'themes', ''),

--- a/plugin.video.catchuptvandmore/resources/lib/websites/lesargonautes.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/lesargonautes.py
@@ -44,14 +44,8 @@ URL_STREAM = 'https://mnmedias.api.telequebec.tv/m3u8/%s.m3u8'
 # VideoId
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     resp = urlquick.get(URL_VIDEOS)
     list_seasons_datas = re.compile(r'li path\=\"(.*?)\"').findall(resp.text)

--- a/plugin.video.catchuptvandmore/resources/lib/websites/marmiton.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/marmiton.py
@@ -27,14 +27,8 @@ from codequick import Route, Resolver, Listitem, youtube
 from resources.lib.menu_utils import item_post_treatment
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin)
-
-
-def root(plugin, **kwargs):
+@Route.register
+def website_root(plugin, **kwargs):
     item = Listitem()
     item.label = 'Marmiton (youtube)'
     item.set_callback(list_videos_youtube,

--- a/plugin.video.catchuptvandmore/resources/lib/websites/nationalfff.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/nationalfff.py
@@ -38,14 +38,8 @@ URL_REPLAY = URL_ROOT + '/playback/loadmore/national/%s'
 # TODO Add Live
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     item = Listitem()
     item.label = plugin.localize(30701)

--- a/plugin.video.catchuptvandmore/resources/lib/websites/nfb.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/nfb.py
@@ -39,13 +39,6 @@ URL_VIDEOS = URL_ROOT + '/remote/explore-all-films/?language=en&genre=%s&availab
 # Genre, Page
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
 GENRE_VIDEOS = {
     '61': 'Animation',
     '63': 'Children\'s film',
@@ -58,7 +51,8 @@ GENRE_VIDEOS = {
 }
 
 
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     for category_id, category_title in list(GENRE_VIDEOS.items()):
         item = Listitem()

--- a/plugin.video.catchuptvandmore/resources/lib/websites/noob.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/noob.py
@@ -32,13 +32,6 @@ import urlquick
 URL_ROOT = 'http://noob-tv.com'
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
 CATEGORIES = {
     'Noob': URL_ROOT + '/videos.php?id=1',
     'WarpZone Project': URL_ROOT + '/videos.php?id=4',
@@ -50,7 +43,8 @@ CATEGORIES = {
 }
 
 
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     for category_name, category_url in list(CATEGORIES.items()):
         item = Listitem()

--- a/plugin.video.catchuptvandmore/resources/lib/websites/notrehistoirech.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/notrehistoirech.py
@@ -35,14 +35,8 @@ import urlquick
 URL_ROOT = 'http://www.notrehistoire.ch'
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     item = Listitem()
     item.label = plugin.localize(30701)

--- a/plugin.video.catchuptvandmore/resources/lib/websites/nytimes.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/nytimes.py
@@ -46,14 +46,8 @@ URL_STREAM = URL_ROOT + '/svc/video/api/v3/video/%s'
 # videoId
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     resp = urlquick.get(URL_VIDEOS)
     root = resp.parse()

--- a/plugin.video.catchuptvandmore/resources/lib/websites/onf.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/onf.py
@@ -39,13 +39,6 @@ URL_VIDEOS = URL_ROOT + '/remote/explorer-tous-les-films/?language=fr&genre=%s&a
 # Genre, Page
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
 GENRE_VIDEOS = {
     '64': 'Actualité (1940-1965)',
     '61': 'Animation',
@@ -58,7 +51,8 @@ GENRE_VIDEOS = {
 }
 
 
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     for category_id, category_title in list(GENRE_VIDEOS.items()):
         item = Listitem()

--- a/plugin.video.catchuptvandmore/resources/lib/websites/philharmoniedeparis.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/philharmoniedeparis.py
@@ -40,14 +40,8 @@ URL_REPLAYS = URL_ROOT + '/misc/AjaxListVideo.ashx?/Concerts/%s'
 URL_STREAM = URL_ROOT + '/otoPlayer/config.ashx?id=%s'
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     """
     Build categories listing

--- a/plugin.video.catchuptvandmore/resources/lib/websites/taratata.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/taratata.py
@@ -46,15 +46,8 @@ SHOW_INFO_FTV = 'https://api-embed.webservices.francetelevisions.fr/v2/key/%s'
 # idEmbeded
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root_taratata(plugin, item_id)
-
-
 @Route.register
-def root_taratata(plugin, item_id, **kwargs):
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     resp = urlquick.get(URL_ROOT(''))
     root = resp.parse("ul", attrs={"class": "nav navbar-nav"})

--- a/plugin.video.catchuptvandmore/resources/lib/websites/tetesaclaques.py
+++ b/plugin.video.catchuptvandmore/resources/lib/websites/tetesaclaques.py
@@ -36,14 +36,8 @@ from resources.lib.menu_utils import item_post_treatment
 URL_ROOT = utils.urljoin_partial('https://www.tetesaclaques.tv')
 
 
-def website_entry(plugin, item_id, **kwargs):
-    """
-    First executed function after website_bridge
-    """
-    return root(plugin, item_id)
-
-
-def root(plugin, item_id, **kwargs):
+@Route.register
+def website_root(plugin, item_id, **kwargs):
     """Add modes in the listing"""
     resp = urlquick.get(URL_ROOT(''))
     root = resp.parse("li", attrs={"id": "menu-videos"})

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_all.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_all.m3u
@@ -6,542 +6,532 @@
 ##	TF1
 ##	tf1
 #EXTINF:-1 tvg-id="C192.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tf1.png" group-title="France",TF1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tf1&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tf1
 
 ##	France 2
 ##	france-2
 #EXTINF:-1 tvg-id="C4.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france2.png" group-title="France",France 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-2&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-2
 
 ##	France 3
 ##	france-3
 #EXTINF:-1 tvg-id="C80.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3.png" group-title="France",France 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-3&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-3
 
 ##	Canal +
 ##	canalplus
 #EXTINF:-1 tvg-id="C34.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/canalplus.png" group-title="France",Canal +
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=canalplus&item_module=resources.lib.channels.fr.mycanal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal/get_live_url/?item_id=canalplus
 
 ##	France 5
 ##	france-5
 #EXTINF:-1 tvg-id="C47.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france5.png" group-title="France",France 5
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-5&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-5
 
 ##	M6
 ##	m6
 #EXTINF:-1 tvg-id="C118.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/m6.png" group-title="France",M6
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=m6&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=m6
 
 ##	C8
 ##	c8
 #EXTINF:-1 tvg-id="C445.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/c8.png" group-title="France",C8
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=c8&item_module=resources.lib.channels.fr.mycanal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal/get_live_url/?item_id=c8
 
 ##	W9
 ##	w9
 #EXTINF:-1 tvg-id="C119.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/w9.png" group-title="France",W9
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=w9&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=w9
 
 ##	TMC
 ##	tmc
 #EXTINF:-1 tvg-id="C195.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tmc.png" group-title="France",TMC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tmc&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tmc
 
 ##	TFX
 ##	tfx
 #EXTINF:-1 tvg-id="C446.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tfx.png" group-title="France",TFX
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tfx&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tfx
 
 ##	NRJ 12
 ##	nrj12
 #EXTINF:-1 tvg-id="C444.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/nrj12.png" group-title="France",NRJ 12
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nrj12&item_module=resources.lib.channels.fr.nrj
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/nrj/get_live_url/?item_id=nrj12
 
 ##	LCP Assemblée Nationale
 ##	lcp
 #EXTINF:-1 tvg-id="C234.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lcp.png" group-title="France",LCP Assemblée Nationale
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lcp&item_module=resources.lib.channels.fr.lcp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lcp/get_live_url/?item_id=lcp
 
 ##	Public Sénat
 ##	publicsenat
 #EXTINF:-1 tvg-id="C234.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/publicsenat.png" group-title="France",Public Sénat
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=publicsenat&item_module=resources.lib.channels.fr.publicsenat
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/publicsenat/get_live_url/?item_id=publicsenat
 
 ##	France 4
 ##	france-4
 #EXTINF:-1 tvg-id="C78.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france4.png" group-title="France",France 4
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-4&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-4
 
 ##	BFM TV
 ##	bfmtv
 #EXTINF:-1 tvg-id="C481.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmtv.png" group-title="France",BFM TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmtv&item_module=resources.lib.channels.fr.bfmtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmtv/get_live_url/?item_id=bfmtv
 
 ##	CNews
 ##	cnews
 #EXTINF:-1 tvg-id="C226.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/cnews.png" group-title="France",CNews
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cnews&item_module=resources.lib.channels.fr.cnews
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/cnews/get_live_url/?item_id=cnews
 
 ##	CStar
 ##	cstar
 #EXTINF:-1 tvg-id="C458.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/cstar.png" group-title="France",CStar
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cstar&item_module=resources.lib.channels.fr.mycanal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal/get_live_url/?item_id=cstar
 
 ##	Gulli
 ##	gulli
 #EXTINF:-1 tvg-id="C482.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/gulli.png" group-title="France",Gulli
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=gulli&item_module=resources.lib.channels.fr.gulli
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/gulli/get_live_url/?item_id=gulli
 
 ##	France Ô
 ##	france-o
 #EXTINF:-1 tvg-id="C160.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/franceo.png" group-title="France",France Ô
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-o&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-o
 
 ##	TF1 Séries Films
 ##	tf1-series-films
 #EXTINF:-1 tvg-id="C1404.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tf1seriesfilms.png" group-title="France",TF1 Séries Films
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tf1-series-films&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tf1-series-films
 
 ##	L'Équipe
 ##	lequipe
 #EXTINF:-1 tvg-id="C1401.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lequipe.png" group-title="France",L'Équipe
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lequipe&item_module=resources.lib.channels.fr.lequipe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lequipe/get_live_url/?item_id=lequipe
 
 ##	6ter
 ##	6ter
 #EXTINF:-1 tvg-id="C1403.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/6ter.png" group-title="France",6ter
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=6ter&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=6ter
 
 ##	RMC Story
 ##	rmcstory
 #EXTINF:-1 tvg-id="C1402.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rmcstory.png" group-title="France",RMC Story
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rmcstory&item_module=resources.lib.channels.fr.rmc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/rmc/get_live_url/?item_id=rmcstory
 
 ##	RMC Découverte
 ##	rmcdecouverte
 #EXTINF:-1 tvg-id="C1400.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rmcdecouverte.png" group-title="France",RMC Découverte
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rmcdecouverte&item_module=resources.lib.channels.fr.rmc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/rmc/get_live_url/?item_id=rmcdecouverte
 
 ##	Chérie 25
 ##	cherie25
 #EXTINF:-1 tvg-id="C1399.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/cherie25.png" group-title="France",Chérie 25
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cherie25&item_module=resources.lib.channels.fr.nrj
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/nrj/get_live_url/?item_id=cherie25
 
 ##	LCI
 ##	lci
 #EXTINF:-1 tvg-id="C112.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lci.png" group-title="France",LCI
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lci&item_module=resources.lib.channels.fr.lci
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lci/get_live_url/?item_id=lci
 
 ##	France Info
 ##	franceinfo
 #EXTINF:-1 tvg-id="C2111.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/franceinfo.png" group-title="France",France Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=franceinfo&item_module=resources.lib.channels.fr.franceinfo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinfo/get_live_url/?item_id=franceinfo
 
 ##	La 1ère Guadeloupe
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Guadeloupe
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Guadeloupe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Guadeloupe
 
 ##	La 1ère Guyane
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Guyane
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Guyane
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Guyane
 
 ##	La 1ère Martinique
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Martinique
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Martinique
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Martinique
 
 ##	La 1ère Mayotte
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Mayotte
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Mayotte
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Mayotte
 
 ##	La 1ère Nouvelle Calédonie
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Nouvelle Calédonie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Nouvelle+Cal%C3%A9donie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Nouvelle+Cal%C3%A9donie
 
 ##	La 1ère Polynésie
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Polynésie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Polyn%C3%A9sie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Polyn%C3%A9sie
 
 ##	La 1ère Réunion
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Réunion
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=R%C3%A9union
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=R%C3%A9union
 
 ##	La 1ère St-Pierre et Miquelon
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère St-Pierre et Miquelon
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=St-Pierre+et+Miquelon
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=St-Pierre+et+Miquelon
 
 ##	La 1ère Wallis et Futuna
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France",La 1ère Wallis et Futuna
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Wallis+et+Futuna
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Wallis+et+Futuna
 
 ##	BFM Business
 ##	bfmbusiness
 #EXTINF:-1 tvg-id="C1073.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmbusiness.png" group-title="France",BFM Business
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmbusiness&item_module=resources.lib.channels.fr.bfmtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmtv/get_live_url/?item_id=bfmbusiness
 
 ##	France 3 Régions Alpes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Alpes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Alpes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Alpes
 
 ##	France 3 Régions Alsace
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Alsace
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Alsace
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Alsace
 
 ##	France 3 Régions Aquitaine
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Aquitaine
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Aquitaine
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Aquitaine
 
 ##	France 3 Régions Auvergne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Auvergne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Auvergne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Auvergne
 
 ##	France 3 Régions Bourgogne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Bourgogne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Bourgogne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Bourgogne
 
 ##	France 3 Régions Bretagne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Bretagne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Bretagne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Bretagne
 
 ##	France 3 Régions Centre-Val de Loire
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Centre-Val de Loire
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Centre-Val+de+Loire
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Centre-Val+de+Loire
 
 ##	France 3 Régions Chapagne-Ardenne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Chapagne-Ardenne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Chapagne-Ardenne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Chapagne-Ardenne
 
 ##	France 3 Régions Corse
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Corse
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Corse
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Corse
 
 ##	France 3 Régions Côte d'Azur
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Côte d'Azur
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=C%C3%B4te+d%27Azur
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=C%C3%B4te+d%27Azur
 
 ##	France 3 Régions Franche-Comté
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Franche-Comté
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Franche-Comt%C3%A9
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Franche-Comt%C3%A9
 
 ##	France 3 Régions Languedoc-Roussillon
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Languedoc-Roussillon
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Languedoc-Roussillon
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Languedoc-Roussillon
 
 ##	France 3 Régions Limousin
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Limousin
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Limousin
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Limousin
 
 ##	France 3 Régions Lorraine
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Lorraine
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Lorraine
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Lorraine
 
 ##	France 3 Régions Midi-Pyrénées
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Midi-Pyrénées
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Midi-Pyr%C3%A9n%C3%A9es
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Midi-Pyr%C3%A9n%C3%A9es
 
 ##	France 3 Régions Nord-Pas-de-Calais
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Nord-Pas-de-Calais
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Nord-Pas-de-Calais
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Nord-Pas-de-Calais
 
 ##	France 3 Régions Basse-Normandie
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Basse-Normandie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Basse-Normandie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Basse-Normandie
 
 ##	France 3 Régions Haute-Normandie
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Haute-Normandie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Haute-Normandie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Haute-Normandie
 
 ##	France 3 Régions Paris Île-de-France
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Paris Île-de-France
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Paris+%C3%8Ele-de-France
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Paris+%C3%8Ele-de-France
 
 ##	France 3 Régions Pays de la Loire
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Pays de la Loire
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Pays+de+la+Loire
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Pays+de+la+Loire
 
 ##	France 3 Régions Picardie
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Picardie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Picardie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Picardie
 
 ##	France 3 Régions Poitou-Charentes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Poitou-Charentes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Poitou-Charentes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Poitou-Charentes
 
 ##	France 3 Régions Provence-Alpes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Provence-Alpes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Provence-Alpes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Provence-Alpes
 
 ##	France 3 Régions Rhône-Alpes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Rhône-Alpes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Rh%C3%B4ne-Alpes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Rh%C3%B4ne-Alpes
 
 ##	France 3 Régions Nouvelle-Aquitaine
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France",France 3 Régions Nouvelle-Aquitaine
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Nouvelle-Aquitaine
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Nouvelle-Aquitaine
 
 ##	Gong
 ##	gong
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/gong.png" group-title="France",Gong
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=gong&item_module=resources.lib.channels.fr.gong
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/gong/get_live_url/?item_id=gong
 
 ##	BFM Paris
 ##	bfmparis
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmparis.png" group-title="France",BFM Paris
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmparis&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmparis
 
 ##	Fun Radio
 ##	fun_radio
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/funradio.png" group-title="France",Fun Radio
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=fun_radio&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=fun_radio
 
 ##	KTO
 ##	kto
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/kto.png" group-title="France",KTO
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=kto&item_module=resources.lib.channels.fr.kto
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/kto/get_live_url/?item_id=kto
 
 ##	Antenne Réunion
 ##	antennereunion
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/antennereunion.png" group-title="France",Antenne Réunion
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=antennereunion&item_module=resources.lib.channels.fr.antennereunion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/antennereunion/get_live_url/?item_id=antennereunion
 
 ##	viàOccitanie
 ##	viaoccitanie
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viaoccitanie.png" group-title="France",viàOccitanie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viaoccitanie&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viaoccitanie
 
 ##	Ouatch TV
 ##	ouatchtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/ouatchtv.png" group-title="France",Ouatch TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ouatchtv&item_module=resources.lib.channels.fr.ouatchtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/ouatchtv/get_live_url/?item_id=ouatchtv
 
 ##	RTL 2
 ##	rtl2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rtl2.png" group-title="France",RTL 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl2&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=rtl2
 
 ##	viàATV
 ##	viaatv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viaatv.png" group-title="France",viàATV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viaatv&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viaatv
 
 ##	viàGrandParis
 ##	viagrandparis
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viagrandparis.png" group-title="France",viàGrandParis
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viagrandparis&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viagrandparis
 
 ##	Tébéo
 ##	tebeo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tebeo.png" group-title="France",Tébéo
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tebeo&item_module=resources.lib.channels.fr.tebeo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tebeo/get_live_url/?item_id=tebeo
 
 ##	M6 Boutique
 ##	mb
 #EXTINF:-1 tvg-id="C184.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/mb.png" group-title="France",M6 Boutique
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=mb&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=mb
 
 ##	viàLMTv Sarthe
 ##	vialmtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/vialmtv.png" group-title="France",viàLMTv Sarthe
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=vialmtv&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=vialmtv
 
 ##	viàMirabelle
 ##	viamirabelle
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viamirabelle.png" group-title="France",viàMirabelle
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viamirabelle&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viamirabelle
 
 ##	viàVosges
 ##	viavosges
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viavosges.png" group-title="France",viàVosges
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viavosges&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viavosges
 
 ##	Télévision Loire 7
 ##	tl7
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tl7.png" group-title="France",Télévision Loire 7
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tl7&item_module=resources.lib.channels.fr.tl7
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tl7/get_live_url/?item_id=tl7
 
 ##	Lucky Jack
 ##	luckyjack
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/luckyjack.png" group-title="France",Lucky Jack
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=luckyjack&item_module=resources.lib.channels.fr.abweb
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/abweb/get_live_url/?item_id=luckyjack
 
 ##	8 Mont-Blanc
 ##	tv8montblanc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tv8montblanc.png" group-title="France",8 Mont-Blanc
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv8montblanc&item_module=resources.lib.channels.fr.tv8montblanc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tv8montblanc/get_live_url/?item_id=tv8montblanc
 
 ##	Alsace 20
 ##	alsace20
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/alsace20.png" group-title="France",Alsace 20
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=alsace20&item_module=resources.lib.channels.fr.alsace20
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/alsace20/get_live_url/?item_id=alsace20
 
 ##	TVPI télévision d'ici
 ##	tvpifr
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvpifr.png" group-title="France",TVPI télévision d'ici
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvpifr&item_module=resources.lib.channels.fr.tvpifr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvpifr/get_live_url/?item_id=tvpifr
 
 ##	IDF 1
 ##	idf1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/idf1.png" group-title="France",IDF 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=idf1&item_module=resources.lib.channels.fr.idf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/idf1/get_live_url/?item_id=idf1
 
 ##	Azur TV
 ##	azurtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/azurtv.png" group-title="France",Azur TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=azurtv&item_module=resources.lib.channels.fr.azurtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/azurtv/get_live_url/?item_id=azurtv
 
 ##	BIP TV
 ##	biptv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/biptv.png" group-title="France",BIP TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=biptv&item_module=resources.lib.channels.fr.biptv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/biptv/get_live_url/?item_id=biptv
 
 ##	BFM Lille
 ##	bfmlille
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmlille.png" group-title="France",BFM Lille
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmlille&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmlille
 
 ##	BFM Littoral
 ##	bfmgrandlittoral
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmgrandlittoral.png" group-title="France",BFM Littoral
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmgrandlittoral&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmgrandlittoral
 
 ##	La Chaine Normande
 ##	lachainenormande
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lachainenormande.png" group-title="France",La Chaine Normande
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lachainenormande&item_module=resources.lib.channels.fr.lachainenormande
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lachainenormande/get_live_url/?item_id=lachainenormande
 
 ##	Sport en France
 ##	sportenfrance
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/sportenfrance.png" group-title="France",Sport en France
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=sportenfrance&item_module=resources.lib.channels.fr.sportenfrance
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/sportenfrance/get_live_url/?item_id=sportenfrance
 
 ##	Provence Azur TV
 ##	provenceazurtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/provenceazurtv.png" group-title="France",Provence Azur TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=provenceazurtv&item_module=resources.lib.channels.fr.azurtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/azurtv/get_live_url/?item_id=provenceazurtv
 
 ##	TébéSud
 ##	tebesud
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tebesud.png" group-title="France",TébéSud
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tebesud&item_module=resources.lib.channels.fr.tebeo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tebeo/get_live_url/?item_id=tebesud
 
 ##	TéléGrenoble
 ##	telegrenoble
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/telegrenoble.png" group-title="France",TéléGrenoble
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telegrenoble&item_module=resources.lib.channels.fr.telegrenoble
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/telegrenoble/get_live_url/?item_id=telegrenoble
 
 ##	TéléNantes
 ##	telenantes
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/telenantes.png" group-title="France",TéléNantes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telenantes&item_module=resources.lib.channels.fr.telenantes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/telenantes/get_live_url/?item_id=telenantes
 
 ##	BFM Lyon
 ##	bfmlyon
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmlyon.png" group-title="France",BFM Lyon
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmlyon&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmlyon
 
 ##	TLC
 ##	tlc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tlc.png" group-title="France",TLC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tlc&item_module=resources.lib.channels.fr.tlc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tlc/get_live_url/?item_id=tlc
 
 ##	TV Vendée
 ##	tvvendee
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvvendee.png" group-title="France",TV Vendée
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvvendee&item_module=resources.lib.channels.fr.tvvendee
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvvendee/get_live_url/?item_id=tvvendee
 
 ##	TV7 Bordeaux
 ##	tv7bordeaux
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tv7bordeaux.png" group-title="France",TV7 Bordeaux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv7bordeaux&item_module=resources.lib.channels.fr.tv7bordeaux
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tv7bordeaux/get_live_url/?item_id=tv7bordeaux
 
 ##	TVT Val de Loire
 ##	tvt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvt.png" group-title="France",TVT Val de Loire
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvt&item_module=resources.lib.channels.fr.tvt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvt/get_live_url/?item_id=tvt
 
 ##	TVR
 ##	tvr
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvr.png" group-title="France",TVR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvr&item_module=resources.lib.channels.fr.tvr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvr/get_live_url/?item_id=tvr
 
 ##	Wéo TV
 ##	weo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/weo.png" group-title="France",Wéo TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=weo&item_module=resources.lib.channels.fr.weo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/weo/get_live_url/?item_id=weo
 
 ##	DiCi TV
 ##	dicitv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/dicitv.png" group-title="France",DiCi TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dicitv&item_module=resources.lib.channels.fr.dicitv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/dicitv/get_live_url/?item_id=dicitv
 
 ##	viàMaTélé
 ##	viamatele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viamatele.png" group-title="France",viàMaTélé
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viamatele&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viamatele
 
 ##	France Inter
 ##	franceinter
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/franceinter.png" group-title="France",France Inter
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=franceinter&item_module=resources.lib.channels.fr.franceinter
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinter/get_live_url/?item_id=franceinter
 
 ##	RTL
 ##	rtl
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rtl.png" group-title="France",RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl&item_module=resources.lib.channels.fr.rtl
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/rtl/get_live_url/?item_id=rtl
 
 ##	Europe 1
 ##	europe1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/europe1.png" group-title="France",Europe 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=europe1&item_module=resources.lib.channels.fr.europe1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/europe1/get_live_url/?item_id=europe1
 
 ##	01Net TV
 ##	01net
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/01net.png" group-title="France",01Net TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=01net&item_module=resources.lib.channels.fr.01net
-
-##	Equidia
-##	equidia
-#EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/equidia.png" group-title="France",Equidia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=equidia&item_module=resources.lib.channels.fr.equidia
-
-##	B Smart
-##	bsmart
-#EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bsmart.png" group-title="France",B Smart
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bsmart&item_module=resources.lib.channels.fr.bsmart
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/01net/get_live_url/?item_id=01net
 
 
 
@@ -551,87 +541,87 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=b
 ##	Rouge TV
 ##	rougetv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rougetv.png" group-title="Switzerland",Rouge TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rougetv&item_module=resources.lib.channels.ch.rougetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/rougetv/get_live_url/?item_id=rougetv
 
 ##	TVM3
 ##	tvm3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/tvm3.png" group-title="Switzerland",TVM3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvm3&item_module=resources.lib.channels.ch.tvm3
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/tvm3/get_live_url/?item_id=tvm3
 
 ##	RTS Un
 ##	rtsun
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtsun.png" group-title="Switzerland",RTS Un
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtsun&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtsun
 
 ##	RTS Deux
 ##	rtsdeux
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtsdeux.png" group-title="Switzerland",RTS Deux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtsdeux&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtsdeux
 
 ##	RTS Info
 ##	rtsinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtsinfo.png" group-title="Switzerland",RTS Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtsinfo&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtsinfo
 
 ##	RTS Couleur 3
 ##	rtscouleur3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtscouleur3.png" group-title="Switzerland",RTS Couleur 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtscouleur3&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtscouleur3
 
 ##	RTS La 1
 ##	rsila1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rsila1.png" group-title="Switzerland",RTS La 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rsila1&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rsila1
 
 ##	RTS La 2
 ##	rsila2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rsila2.png" group-title="Switzerland",RTS La 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rsila2&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rsila2
 
 ##	SRF 1
 ##	srf1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/srf1.png" group-title="Switzerland",SRF 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=srf1&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=srf1
 
 ##	SRF Info
 ##	srfinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/srfinfo.png" group-title="Switzerland",SRF Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=srfinfo&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=srfinfo
 
 ##	SRF Zwei
 ##	srfzwei
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/srfzwei.png" group-title="Switzerland",SRF Zwei
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=srfzwei&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=srfzwei
 
 ##	RTR auf SRF 1
 ##	rtraufsrf1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtraufsrf1.png" group-title="Switzerland",RTR auf SRF 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtraufsrf1&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtraufsrf1
 
 ##	RTR auf SRF Info
 ##	rtraufsrfinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtraufsrfinfo.png" group-title="Switzerland",RTR auf SRF Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtraufsrfinfo&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtraufsrfinfo
 
 ##	RTR auf SRF 2
 ##	rtraufsrf2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtraufsrf2.png" group-title="Switzerland",RTR auf SRF 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtraufsrf2&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtraufsrf2
 
 ##	Teleticino
 ##	teleticino
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/teleticino.png" group-title="Switzerland",Teleticino
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=teleticino&item_module=resources.lib.channels.ch.teleticino
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/teleticino/get_live_url/?item_id=teleticino
 
 ##	Léman Bleu
 ##	lemanbleu
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/lemanbleu.png" group-title="Switzerland",Léman Bleu
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lemanbleu&item_module=resources.lib.channels.ch.lemanbleu
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/lemanbleu/get_live_url/?item_id=lemanbleu
 
 ##	Tele M1
 ##	telem1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/telem1.png" group-title="Switzerland",Tele M1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telem1&item_module=resources.lib.channels.ch.telem1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/telem1/get_live_url/?item_id=telem1
 
 
 
@@ -641,112 +631,112 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=t
 ##	Blaze
 ##	blaze
 #EXTINF:-1 tvg-id="1013.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/blaze.png" group-title="United Kingdom",Blaze
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=blaze&item_module=resources.lib.channels.uk.blaze
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/blaze/get_live_url/?item_id=blaze
 
 ##	Dave
 ##	dave
 #EXTINF:-1 tvg-id="432.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/dave.png" group-title="United Kingdom",Dave
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dave&item_module=resources.lib.channels.uk.uktvplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay/get_live_url/?item_id=dave
 
 ##	Yesterday
 ##	yesterday
 #EXTINF:-1 tvg-id="320.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/yesterday.png" group-title="United Kingdom",Yesterday
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=yesterday&item_module=resources.lib.channels.uk.uktvplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay/get_live_url/?item_id=yesterday
 
 ##	Drama
 ##	drama
 #EXTINF:-1 tvg-id="871.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/drama.png" group-title="United Kingdom",Drama
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=drama&item_module=resources.lib.channels.uk.uktvplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay/get_live_url/?item_id=drama
 
 ##	Sky News
 ##	skynews
 #EXTINF:-1 tvg-id="257.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/skynews.png" group-title="United Kingdom",Sky News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=skynews&item_module=resources.lib.channels.uk.sky
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/sky/get_live_url/?item_id=skynews
 
 ##	STV
 ##	stv
 #EXTINF:-1 tvg-id="178.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/stv.png" group-title="United Kingdom",STV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=stv&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=stv
 
 ##	Kerrang
 ##	kerrang
 #EXTINF:-1 tvg-id="1207.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/kerrang.png" group-title="United Kingdom",Kerrang
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=kerrang&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=kerrang
 
 ##	Magic
 ##	magic
 #EXTINF:-1 tvg-id="185.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/magic.png" group-title="United Kingdom",Magic
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=magic&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=magic
 
 ##	Kiss
 ##	kiss
 #EXTINF:-1 tvg-id="182.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/kiss.png" group-title="United Kingdom",Kiss
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=kiss&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=kiss
 
 ##	The Box
 ##	the-box
 #EXTINF:-1 tvg-id="279.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/thebox.png" group-title="United Kingdom",The Box
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=the-box&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=the-box
 
 ##	Box Hits
 ##	box-hits
 #EXTINF:-1 tvg-id="267.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/boxhits.png" group-title="United Kingdom",Box Hits
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=box-hits&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=box-hits
 
 ##	Box Upfront
 ##	box-upfront
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/boxupfront.png" group-title="United Kingdom",Box Upfront
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=box-upfront&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=box-upfront
 
 ##	Quest TV
 ##	questtv
 #EXTINF:-1 tvg-id="1230.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/questtv.png" group-title="United Kingdom",Quest TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=questtv&item_module=resources.lib.channels.uk.questod
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/questod/get_live_url/?item_id=questtv
 
 ##	Quest RED
 ##	questred
 #EXTINF:-1 tvg-id="1014.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/questred.png" group-title="United Kingdom",Quest RED
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=questred&item_module=resources.lib.channels.uk.questod
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/questod/get_live_url/?item_id=questred
 
 ##	Bristol TV
 ##	bristoltv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/bristoltv.png" group-title="United Kingdom",Bristol TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bristoltv&item_module=resources.lib.channels.uk.bristoltv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/bristoltv/get_live_url/?item_id=bristoltv
 
 ##	Free Sports
 ##	freesports
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/freesports.png" group-title="United Kingdom",Free Sports
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=freesports&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=freesports
 
 ##	STV+1
 ##	stv_plusone
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/stv_plusone.png" group-title="United Kingdom",STV+1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=stv_plusone&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=stv_plusone
 
 ##	EDGE Sport
 ##	edgesport
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/edgesport.png" group-title="United Kingdom",EDGE Sport
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=edgesport&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=edgesport
 
 ##	The Pet Collective
 ##	thepetcollective
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/thepetcollective.png" group-title="United Kingdom",The Pet Collective
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=thepetcollective&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=thepetcollective
 
 ##	Fail Army
 ##	failarmy
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/failarmy.png" group-title="United Kingdom",Fail Army
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=failarmy&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=failarmy
 
 ##	Qello
 ##	qello
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/qello.png" group-title="United Kingdom",Qello
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qello&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=qello
 
 ##	DUST
 ##	dust
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/dust.png" group-title="United Kingdom",DUST
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dust&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=dust
 
 
 
@@ -756,247 +746,247 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=d
 ##	Euronews FR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=FR
 
 ##	Euronews EN
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=EN
 
 ##	Euronews AR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=AR
 
 ##	Euronews DE
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=DE
 
 ##	Euronews IT
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews IT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=IT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=IT
 
 ##	Euronews ES
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=ES
 
 ##	Euronews PT
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews PT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=PT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=PT
 
 ##	Euronews RU
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews RU
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=RU
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=RU
 
 ##	Euronews TR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews TR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=TR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=TR
 
 ##	Euronews FA
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews FA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=FA
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=FA
 
 ##	Euronews GR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews GR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=GR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=GR
 
 ##	Euronews HU
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews HU
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=HU
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=HU
 
 ##	Arte FR
 ##	arte
 #EXTINF:-1 tvg-id="C111.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/arte.png" group-title="International",Arte FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arte&item_module=resources.lib.channels.wo.arte&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/arte/get_live_url/?item_id=arte&language=FR
 
 ##	Arte DE
 ##	arte
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/arte.png" group-title="International",Arte DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arte&item_module=resources.lib.channels.wo.arte&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/arte/get_live_url/?item_id=arte&language=DE
 
 ##	France 24 FR
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=FR
 
 ##	France 24 EN
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=EN
 
 ##	France 24 AR
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=AR
 
 ##	France 24 ES
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=ES
 
 ##	NHK World Outside Japan
 ##	nhkworld
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/nhkworld.png" group-title="International",NHK World Outside Japan
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nhkworld&item_module=resources.lib.channels.wo.nhkworld&language=Outside+Japan
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/nhkworld/get_live_url/?item_id=nhkworld&language=Outside+Japan
 
 ##	NHK World In Japan
 ##	nhkworld
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/nhkworld.png" group-title="International",NHK World In Japan
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nhkworld&item_module=resources.lib.channels.wo.nhkworld&language=In+Japan
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/nhkworld/get_live_url/?item_id=nhkworld&language=In+Japan
 
 ##	Tivi 5Monde
 ##	tivi5monde
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/tivi5monde.png" group-title="International",Tivi 5Monde
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tivi5monde&item_module=resources.lib.channels.wo.tivi5monde
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/tivi5monde/get_live_url/?item_id=tivi5monde
 
 ##	BVN
 ##	bvn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/bvn.png" group-title="International",BVN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bvn&item_module=resources.lib.channels.wo.bvn
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/bvn/get_live_url/?item_id=bvn
 
 ##	ICI Télévision
 ##	icitelevision
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/icitelevision.png" group-title="International",ICI Télévision
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitelevision&item_module=resources.lib.channels.wo.icitelevision
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/icitelevision/get_live_url/?item_id=icitelevision
 
 ##	Arirang (아리랑)
 ##	arirang
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/arirang.png" group-title="International",Arirang (아리랑)
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arirang&item_module=resources.lib.channels.wo.arirang
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/arirang/get_live_url/?item_id=arirang
 
 ##	DW EN
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=EN
 
 ##	DW AR
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=AR
 
 ##	DW ES
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=ES
 
 ##	DW DE
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=DE
 
 ##	QVC JP
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC JP
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=JP
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=JP
 
 ##	QVC DE
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=DE
 
 ##	QVC IT
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC IT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=IT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=IT
 
 ##	QVC UK
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC UK
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=UK
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=UK
 
 ##	QVC US
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC US
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=US
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=US
 
 ##	ICI RDI
 ##	icirdi
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/icirdi.png" group-title="International",ICI RDI
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icirdi&item_module=resources.lib.channels.wo.icirdi
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/icirdi/get_live_url/?item_id=icirdi
 
 ##	CGTN FR
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=FR
 
 ##	CGTN EN
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=EN
 
 ##	CGTN AR
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=AR
 
 ##	CGTN ES
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=ES
 
 ##	CGTN RU
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN RU
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=RU
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=RU
 
 ##	CGTN Documentary
 ##	cgtndocumentary
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtndocumentary.png" group-title="International",CGTN Documentary
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtndocumentary&item_module=resources.lib.channels.wo.cgtn
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtndocumentary
 
 ##	Afrique Media
 ##	afriquemedia
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/afriquemedia.png" group-title="International",Afrique Media
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=afriquemedia&item_module=resources.lib.channels.wo.afriquemedia
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/afriquemedia/get_live_url/?item_id=afriquemedia
 
 ##	TV5Monde France Belgique Suisse
 ##	tv5mondefbs
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/tv5mondefbs.png" group-title="International",TV5Monde France Belgique Suisse
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv5mondefbs&item_module=resources.lib.channels.wo.tv5monde
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5monde/get_live_url/?item_id=tv5mondefbs
 
 ##	TV5Monde Info
 ##	tv5mondeinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/tv5mondeinfo.png" group-title="International",TV5Monde Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv5mondeinfo&item_module=resources.lib.channels.wo.tv5monde
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5monde/get_live_url/?item_id=tv5mondeinfo
 
 ##	Channel NewsAsia
 ##	channelnewsasia
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/channelnewsasia.png" group-title="International",Channel NewsAsia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=channelnewsasia&item_module=resources.lib.channels.wo.channelnewsasia
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/channelnewsasia/get_live_url/?item_id=channelnewsasia
 
 ##	RT FR
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=FR
 
 ##	RT EN
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=EN
 
 ##	RT AR
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=AR
 
 ##	RT ES
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=ES
 
 ##	Africa 24
 ##	africa24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/africa24.png" group-title="International",Africa 24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=africa24&item_module=resources.lib.channels.wo.africa24
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/africa24/get_live_url/?item_id=africa24
 
 
 
@@ -1006,122 +996,122 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=a
 ##	RTL-TVI
 ##	rtl_tvi
 #EXTINF:-1 tvg-id="C168.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtltvi.png" group-title="Belgium",RTL-TVI
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl_tvi&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=rtl_tvi
 
 ##	PLUG RTL
 ##	plug_rtl
 #EXTINF:-1 tvg-id="C377.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/plugrtl.png" group-title="Belgium",PLUG RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=plug_rtl&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=plug_rtl
 
 ##	CLUB RTL
 ##	club_rtl
 #EXTINF:-1 tvg-id="C50.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/clubrtl.png" group-title="Belgium",CLUB RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=club_rtl&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=club_rtl
 
 ##	Télé MB
 ##	telemb
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/telemb.png" group-title="Belgium",Télé MB
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telemb&item_module=resources.lib.channels.be.telemb
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/telemb/get_live_url/?item_id=telemb
 
 ##	RTC Télé Liège
 ##	rtc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtc.png" group-title="Belgium",RTC Télé Liège
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtc&item_module=resources.lib.channels.be.rtc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtc/get_live_url/?item_id=rtc
 
 ##	TV Lux
 ##	tvlux
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/tvlux.png" group-title="Belgium",TV Lux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvlux&item_module=resources.lib.channels.be.tvlux
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/tvlux/get_live_url/?item_id=tvlux
 
 ##	RTL INFO
 ##	rtl_info
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtlinfo.png" group-title="Belgium",RTL INFO
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl_info&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=rtl_info
 
 ##	BEL RTL
 ##	bel_rtl
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/belrtl.png" group-title="Belgium",BEL RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bel_rtl&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=bel_rtl
 
 ##	Contact
 ##	contact
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/contact.png" group-title="Belgium",Contact
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=contact&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=contact
 
 ##	BX1
 ##	bx1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/bx1.png" group-title="Belgium",BX1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bx1&item_module=resources.lib.channels.be.bx1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/bx1/get_live_url/?item_id=bx1
 
 ##	Één
 ##	een
 #EXTINF:-1 tvg-id="C23.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/een.png" group-title="Belgium",Één
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=een&item_module=resources.lib.channels.be.vrt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/vrt/get_live_url/?item_id=een
 
 ##	Canvas
 ##	canvas
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/canvas.png" group-title="Belgium",Canvas
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=canvas&item_module=resources.lib.channels.be.vrt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/vrt/get_live_url/?item_id=canvas
 
 ##	Ketnet
 ##	ketnet
 #EXTINF:-1 tvg-id="C1280.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ketnet.png" group-title="Belgium",Ketnet
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ketnet&item_module=resources.lib.channels.be.vrt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/vrt/get_live_url/?item_id=ketnet
 
 ##	NRJ Hits TV
 ##	nrjhitstvbe
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/nrjhitstvbe.png" group-title="Belgium",NRJ Hits TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nrjhitstvbe&item_module=resources.lib.channels.be.nrjhitstvbe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/nrjhitstvbe/get_live_url/?item_id=nrjhitstvbe
 
 ##	RTL Sport
 ##	rtl_sport
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtlsport.png" group-title="Belgium",RTL Sport
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl_sport&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=rtl_sport
 
 ##	TV Com
 ##	tvcom
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/tvcom.png" group-title="Belgium",TV Com
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvcom&item_module=resources.lib.channels.be.tvcom
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/tvcom/get_live_url/?item_id=tvcom
 
 ##	Canal C
 ##	canalc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/canalc.png" group-title="Belgium",Canal C
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=canalc&item_module=resources.lib.channels.be.canalc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/canalc/get_live_url/?item_id=canalc
 
 ##	ABXPLORE
 ##	abxplore
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/abxplore.png" group-title="Belgium",ABXPLORE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=abxplore&item_module=resources.lib.channels.be.abbe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/abbe/get_live_url/?item_id=abxplore
 
 ##	AB3
 ##	ab3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ab3.png" group-title="Belgium",AB3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ab3&item_module=resources.lib.channels.be.abbe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/abbe/get_live_url/?item_id=ab3
 
 ##	LN24
 ##	ln24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ln24.png" group-title="Belgium",LN24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ln24&item_module=resources.lib.channels.be.ln24
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/ln24/get_live_url/?item_id=ln24
 
 ##	La Une
 ##	laune
 #EXTINF:-1 tvg-id="C164.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/laune.png" group-title="Belgium",La Une
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=laune&item_module=resources.lib.channels.be.rtbf
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf/set_live_url/?item_id=laune
 
 ##	La Deux
 ##	ladeux
 #EXTINF:-1 tvg-id="C187.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ladeux.png" group-title="Belgium",La Deux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ladeux&item_module=resources.lib.channels.be.rtbf
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf/set_live_url/?item_id=ladeux
 
 ##	La Trois
 ##	latrois
 #EXTINF:-1 tvg-id="C892.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/latrois.png" group-title="Belgium",La Trois
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=latrois&item_module=resources.lib.channels.be.rtbf
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf/set_live_url/?item_id=latrois
 
 ##	Antenne Centre TV
 ##	actv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/actv.png" group-title="Belgium",Antenne Centre TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=actv&item_module=resources.lib.channels.be.actv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/actv/get_live_url/?item_id=actv
 
 
 
@@ -1131,17 +1121,17 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=a
 ##	日テレ News24
 ##	ntvnews24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/jp/ntvnews24.png" group-title="Japan",日テレ News24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ntvnews24&item_module=resources.lib.channels.jp.ntvnews24
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/jp/ntvnews24/get_live_url/?item_id=ntvnews24
 
 ##	ジャパネットチャンネルDX
 ##	japanetshoppingdx
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/jp/japanetshoppingdx.png" group-title="Japan",ジャパネットチャンネルDX
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=japanetshoppingdx&item_module=resources.lib.channels.jp.japanetshoppingdx
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/jp/japanetshoppingdx/get_live_url/?item_id=japanetshoppingdx
 
 ##	株式会社ウェザーニューズ
 ##	weathernewsjp
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/jp/weathernewsjp.png" group-title="Japan",株式会社ウェザーニューズ
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=weathernewsjp&item_module=resources.lib.channels.jp.weathernewsjp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/jp/weathernewsjp/get_live_url/?item_id=weathernewsjp
 
 
 
@@ -1151,147 +1141,147 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=w
 ##	Télé-Québec
 ##	telequebec
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/telequebec.png" group-title="Canada",Télé-Québec
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telequebec&item_module=resources.lib.channels.ca.telequebec
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/telequebec/get_live_url/?item_id=telequebec
 
 ##	TVA
 ##	tva
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/tva.png" group-title="Canada",TVA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tva&item_module=resources.lib.channels.ca.tva
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/tva/get_live_url/?item_id=tva
 
 ##	ICI Télé Vancouver
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Vancouver
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Vancouver
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Vancouver
 
 ##	ICI Télé Regina
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Regina
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Regina
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Regina
 
 ##	ICI Télé Toronto
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Toronto
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Toronto
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Toronto
 
 ##	ICI Télé Edmonton
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Edmonton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Edmonton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Edmonton
 
 ##	ICI Télé Rimouski
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Rimouski
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Rimouski
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Rimouski
 
 ##	ICI Télé Québec
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Québec
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Qu%C3%A9bec
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Qu%C3%A9bec
 
 ##	ICI Télé Winnipeg
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Winnipeg
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Winnipeg
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Winnipeg
 
 ##	ICI Télé Moncton
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Moncton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Moncton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Moncton
 
 ##	ICI Télé Ottawa
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Ottawa
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Ottawa
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Ottawa
 
 ##	ICI Télé Montréal
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Montréal
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Montr%C3%A9al
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Montr%C3%A9al
 
 ##	NTV
 ##	ntvca
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/ntvca.png" group-title="Canada",NTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ntvca&item_module=resources.lib.channels.ca.ntvca
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/ntvca/get_live_url/?item_id=ntvca
 
 ##	Télé-Mag
 ##	telemag
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/telemag.png" group-title="Canada",Télé-Mag
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telemag&item_module=resources.lib.channels.ca.telemag
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/telemag/get_live_url/?item_id=telemag
 
 ##	V Télé
 ##	vtele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/vtele.png" group-title="Canada",V Télé
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=vtele&item_module=resources.lib.channels.ca.noovo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/noovo/get_live_url/?item_id=vtele
 
 ##	CBC Ottawa
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Ottawa
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Ottawa
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Ottawa
 
 ##	CBC Montreal
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Montreal
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Montreal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Montreal
 
 ##	CBC Charlottetown
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Charlottetown
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Charlottetown
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Charlottetown
 
 ##	CBC Fredericton
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Fredericton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Fredericton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Fredericton
 
 ##	CBC Halifax
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Halifax
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Halifax
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Halifax
 
 ##	CBC Windsor
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Windsor
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Windsor
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Windsor
 
 ##	CBC Yellowknife
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Yellowknife
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Yellowknife
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Yellowknife
 
 ##	CBC Winnipeg
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Winnipeg
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Winnipeg
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Winnipeg
 
 ##	CBC Regina
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Regina
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Regina
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Regina
 
 ##	CBC Calgary
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Calgary
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Calgary
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Calgary
 
 ##	CBC Edmonton
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Edmonton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Edmonton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Edmonton
 
 ##	CBC Vancouver
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Vancouver
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Vancouver
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Vancouver
 
 ##	CBC Toronto
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Toronto
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Toronto
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Toronto
 
 ##	CBC St. John's
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC St. John's
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=St.+John%27s
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=St.+John%27s
 
 
 
@@ -1301,22 +1291,22 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=c
 ##	CBS News
 ##	cbsnews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/cbsnews.png" group-title="United States of America",CBS News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbsnews&item_module=resources.lib.channels.us.cbsnews
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/cbsnews/get_live_url/?item_id=cbsnews
 
 ##	TBD
 ##	tbd
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/tbd.png" group-title="United States of America",TBD
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tbd&item_module=resources.lib.channels.us.tbd
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/tbd/get_live_url/?item_id=tbd
 
 ##	ABC News
 ##	abcnews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/abcnews.png" group-title="United States of America",ABC News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=abcnews&item_module=resources.lib.channels.us.abcnews
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/abcnews/get_live_url/?item_id=abcnews
 
 ##	PBS Kids
 ##	pbskids
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/pbskids.png" group-title="United States of America",PBS Kids
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=pbskids&item_module=resources.lib.channels.us.pbskids
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/pbskids/get_live_url/?item_id=pbskids
 
 
 
@@ -1326,97 +1316,97 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=p
 ##	TVP 3 Białystok
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Białystok
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Bia%C5%82ystok
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Bia%C5%82ystok
 
 ##	TVP 3 Bydgoszcz
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Bydgoszcz
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Bydgoszcz
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Bydgoszcz
 
 ##	TVP 3 Gdańsk
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Gdańsk
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Gda%C5%84sk
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Gda%C5%84sk
 
 ##	TVP 3 Gorzów Wielkopolski
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Gorzów Wielkopolski
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Gorz%C3%B3w+Wielkopolski
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Gorz%C3%B3w+Wielkopolski
 
 ##	TVP 3 Katowice
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Katowice
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Katowice
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Katowice
 
 ##	TVP 3 Kielce
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Kielce
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Kielce
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Kielce
 
 ##	TVP 3 Kraków
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Kraków
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Krak%C3%B3w
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Krak%C3%B3w
 
 ##	TVP 3 Lublin
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Lublin
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Lublin
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Lublin
 
 ##	TVP 3 Łódź
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Łódź
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=%C5%81%C3%B3d%C5%BA
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=%C5%81%C3%B3d%C5%BA
 
 ##	TVP 3 Olsztyn
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Olsztyn
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Olsztyn
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Olsztyn
 
 ##	TVP 3 Opole
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Opole
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Opole
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Opole
 
 ##	TVP 3 Poznań
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Poznań
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Pozna%C5%84
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Pozna%C5%84
 
 ##	TVP 3 Rzeszów
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Rzeszów
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Rzesz%C3%B3w
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Rzesz%C3%B3w
 
 ##	TVP 3 Szczecin
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Szczecin
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Szczecin
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Szczecin
 
 ##	TVP 3 Warszawa
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Warszawa
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Warszawa
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Warszawa
 
 ##	TVP 3 Wrocław
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Wrocław
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Wroc%C5%82aw
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Wroc%C5%82aw
 
 ##	TVP Info
 ##	tvpinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvpinfo.png" group-title="Poland",TVP Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvpinfo&item_module=resources.lib.channels.pl.tvp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvpinfo
 
 ##	TVP Polonia
 ##	tvppolonia
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvppolonia.png" group-title="Poland",TVP Polonia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvppolonia&item_module=resources.lib.channels.pl.tvp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvppolonia
 
 ##	TVP Poland IN
 ##	tvppolandin
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvppolandin.png" group-title="Poland",TVP Poland IN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvppolandin&item_module=resources.lib.channels.pl.tvp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvppolandin
 
 
 
@@ -1426,52 +1416,52 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=t
 ##	Telecinco
 ##	telecinco
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/telecinco.png" group-title="Spain",Telecinco
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telecinco&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=telecinco
 
 ##	Cuatro
 ##	cuatro
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/cuatro.png" group-title="Spain",Cuatro
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cuatro&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=cuatro
 
 ##	Factoria de Ficcion
 ##	fdf
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/fdf.png" group-title="Spain",Factoria de Ficcion
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=fdf&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=fdf
 
 ##	Boing
 ##	boing
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/boing.png" group-title="Spain",Boing
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=boing&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=boing
 
 ##	Energy TV
 ##	energy
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/energy.png" group-title="Spain",Energy TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=energy&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=energy
 
 ##	Divinity
 ##	divinity
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/divinity.png" group-title="Spain",Divinity
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=divinity&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=divinity
 
 ##	Be Mad
 ##	bemad
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/bemad.png" group-title="Spain",Be Mad
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bemad&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=bemad
 
 ##	Realmadrid TV EN
 ##	realmadridtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/realmadridtv.png" group-title="Spain",Realmadrid TV EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=realmadridtv&item_module=resources.lib.channels.es.realmadridtv&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/realmadridtv/get_live_url/?item_id=realmadridtv&language=EN
 
 ##	Realmadrid TV ES
 ##	realmadridtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/realmadridtv.png" group-title="Spain",Realmadrid TV ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=realmadridtv&item_module=resources.lib.channels.es.realmadridtv&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/realmadridtv/get_live_url/?item_id=realmadridtv&language=ES
 
 ##	Paramount Channel (ES)
 ##	paramountchannel_es
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/paramountchannel_es.png" group-title="Spain",Paramount Channel (ES)
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=paramountchannel_es&item_module=resources.lib.channels.es.paramountchannel_es
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/paramountchannel_es/get_live_url/?item_id=paramountchannel_es
 
 
 
@@ -1481,17 +1471,17 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=p
 ##	التلفزة التونسية الوطنية 1
 ##	watania1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/tn/watania1.png" group-title="Tunisia",التلفزة التونسية الوطنية 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=watania1&item_module=resources.lib.channels.tn.watania
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/tn/watania/get_live_url/?item_id=watania1
 
 ##	التلفزة التونسية الوطنية 2
 ##	watania2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/tn/watania2.png" group-title="Tunisia",التلفزة التونسية الوطنية 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=watania2&item_module=resources.lib.channels.tn.watania
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/tn/watania/get_live_url/?item_id=watania2
 
 ##	نسمة تي في
 ##	nessma
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/tn/nessma.png" group-title="Tunisia",نسمة تي في
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nessma&item_module=resources.lib.channels.tn.nessma
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/tn/nessma/get_live_url/?item_id=nessma
 
 
 
@@ -1501,77 +1491,77 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=n
 ##	La7
 ##	la7
 #EXTINF:-1 tvg-id="www.la7.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/la7.png" group-title="Italia",La7
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la7&item_module=resources.lib.channels.it.la7
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/la7/get_live_url/?item_id=la7
 
 ##	Rai News 24
 ##	rainews24
 #EXTINF:-1 tvg-id="rainews.guidatv.sky.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rainews24.png" group-title="Italia",Rai News 24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rainews24&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rainews24
 
 ##	Rai 1
 ##	rai1
 #EXTINF:-1 tvg-id="www.raiuno.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai1.png" group-title="Italia",Rai 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai1&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai1
 
 ##	Rai 2
 ##	rai2
 #EXTINF:-1 tvg-id="www.raidue.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai2.png" group-title="Italia",Rai 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai2&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai2
 
 ##	Rai 3
 ##	rai3
 #EXTINF:-1 tvg-id="www.raitre.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai3.png" group-title="Italia",Rai 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai3&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai3
 
 ##	Rai 4
 ##	rai4
 #EXTINF:-1 tvg-id="rai4.raisat.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai4.png" group-title="Italia",Rai 4
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai4&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai4
 
 ##	Rai 5
 ##	rai5
 #EXTINF:-1 tvg-id="rai5.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai5.png" group-title="Italia",Rai 5
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai5&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai5
 
 ##	Rai Sport
 ##	raisportpiuhd
 #EXTINF:-1 tvg-id="raisport.guidatv.sky.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raisportpiuhd.png" group-title="Italia",Rai Sport
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raisportpiuhd&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raisportpiuhd
 
 ##	Rai Movie
 ##	raimovie
 #EXTINF:-1 tvg-id="raimovie.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raimovie.png" group-title="Italia",Rai Movie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raimovie&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raimovie
 
 ##	Rai Premium
 ##	raipremium
 #EXTINF:-1 tvg-id="raipremium.guidatv.sky.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raipremium.png" group-title="Italia",Rai Premium
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raipremium&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raipremium
 
 ##	Rai Yoyo
 ##	raiyoyo
 #EXTINF:-1 tvg-id="yoyo.raisat.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raiyoyo.png" group-title="Italia",Rai Yoyo
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raiyoyo&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raiyoyo
 
 ##	Rai Gulp
 ##	raigulp
 #EXTINF:-1 tvg-id="raigulp.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raigulp.png" group-title="Italia",Rai Gulp
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raigulp&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raigulp
 
 ##	Rai Storia
 ##	raistoria
 #EXTINF:-1 tvg-id="raistoria.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raistoria.png" group-title="Italia",Rai Storia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raistoria&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raistoria
 
 ##	Rai Scuola
 ##	raiscuola
 #EXTINF:-1 tvg-id="raiscuola.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raiscuola.png" group-title="Italia",Rai Scuola
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raiscuola&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raiscuola
 
 ##	Paramount Channel (IT)
 ##	paramountchannel_it
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/paramountchannel_it.png" group-title="Italia",Paramount Channel (IT)
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=paramountchannel_it&item_module=resources.lib.channels.it.paramountchannel_it
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/paramountchannel_it/get_live_url/?item_id=paramountchannel_it
 
 
 
@@ -1581,47 +1571,47 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=p
 ##	NPO 1
 ##	npo-1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo1.png" group-title="Netherlands",NPO 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-1&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-1
 
 ##	NPO 2
 ##	npo-2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo2.png" group-title="Netherlands",NPO 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-2&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-2
 
 ##	NPO 3
 ##	npo-3zapp
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npozapp.png" group-title="Netherlands",NPO 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-3zapp&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-3zapp
 
 ##	NPO 1 Extra
 ##	npo-1-extra
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo1extra.png" group-title="Netherlands",NPO 1 Extra
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-1-extra&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-1-extra
 
 ##	NPO 2 Extra
 ##	npo-2-extra
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo2extra.png" group-title="Netherlands",NPO 2 Extra
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-2-extra&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-2-extra
 
 ##	NPO Zappelin Extra
 ##	npo-zappelin-extra
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npozappelinextra.png" group-title="Netherlands",NPO Zappelin Extra
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-zappelin-extra&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-zappelin-extra
 
 ##	NPO Nieuws
 ##	npo-nieuws
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/nponieuws.png" group-title="Netherlands",NPO Nieuws
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-nieuws&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-nieuws
 
 ##	NPO Politiek
 ##	npo-politiek
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npopolitiek.png" group-title="Netherlands",NPO Politiek
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-politiek&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-politiek
 
 ##	AT5
 ##	at5
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/at5.png" group-title="Netherlands",AT5
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=at5&item_module=resources.lib.channels.nl.at5
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/at5/get_live_url/?item_id=at5
 
 
 
@@ -1631,92 +1621,92 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=a
 ##	CCTV-1 综合
 ##	cctv1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv1.png" group-title="China",CCTV-1 综合
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv1&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv1
 
 ##	CCTV-2 财经
 ##	cctv2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv2.png" group-title="China",CCTV-2 财经
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv2&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv2
 
 ##	CCTV-3 综艺
 ##	cctv3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv3.png" group-title="China",CCTV-3 综艺
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv3&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv3
 
 ##	CCTV-4 中文国际（亚）
 ##	cctv4
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv4.png" group-title="China",CCTV-4 中文国际（亚）
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv4&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv4
 
 ##	CCTV-4 中文国际（欧）
 ##	cctveurope
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctveurope.png" group-title="China",CCTV-4 中文国际（欧）
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctveurope&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctveurope
 
 ##	CCTV-4 中文国际（美）
 ##	cctvamerica
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctvamerica.png" group-title="China",CCTV-4 中文国际（美）
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctvamerica&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctvamerica
 
 ##	CCTV-5 体育
 ##	cctv5
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv5.png" group-title="China",CCTV-5 体育
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv5&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv5
 
 ##	CCTV-5+ 体育赛事
 ##	cctv5plus
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv5plus.png" group-title="China",CCTV-5+ 体育赛事
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv5plus&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv5plus
 
 ##	CCTV-6 电影
 ##	cctv6
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv6.png" group-title="China",CCTV-6 电影
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv6&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv6
 
 ##	CCTV-7 军事农业
 ##	cctv7
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv7.png" group-title="China",CCTV-7 军事农业
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv7&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv7
 
 ##	CCTV-8 电视剧
 ##	cctv8
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv8.png" group-title="China",CCTV-8 电视剧
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv8&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv8
 
 ##	CCTV-9 纪录
 ##	cctvjilu
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctvjilu.png" group-title="China",CCTV-9 纪录
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctvjilu&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctvjilu
 
 ##	CCTV-10 科教
 ##	cctv10
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv10.png" group-title="China",CCTV-10 科教
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv10&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv10
 
 ##	CCTV-11 戏曲
 ##	cctv11
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv11.png" group-title="China",CCTV-11 戏曲
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv11&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv11
 
 ##	CCTV-12 社会与法
 ##	cctv12
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv12.png" group-title="China",CCTV-12 社会与法
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv12&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv12
 
 ##	CCTV-13 新闻
 ##	cctv13
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv13.png" group-title="China",CCTV-13 新闻
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv13&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv13
 
 ##	CCTV-14 少儿
 ##	cctvchild
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctvchild.png" group-title="China",CCTV-14 少儿
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctvchild&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctvchild
 
 ##	CCTV-15 音乐
 ##	cctv15
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv15.png" group-title="China",CCTV-15 音乐
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv15&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv15
 
 
 
@@ -1726,12 +1716,12 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=c
 ##	CRTV
 ##	crtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cm/crtv.png" group-title="Cameroon",CRTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=crtv&item_module=resources.lib.channels.cm.crtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cm/crtv/get_live_url/?item_id=crtv
 
 ##	CRTV News
 ##	crtvnews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cm/crtvnews.png" group-title="Cameroon",CRTV News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=crtvnews&item_module=resources.lib.channels.cm.crtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cm/crtv/get_live_url/?item_id=crtvnews
 
 
 
@@ -1741,32 +1731,32 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=c
 ##	TV SLO 1
 ##	slo1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/slo1.png" group-title="Slovenia",TV SLO 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=slo1&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=slo1
 
 ##	TV SLO 2
 ##	slo2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/slo2.png" group-title="Slovenia",TV SLO 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=slo2&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=slo2
 
 ##	TV SLO 3
 ##	slo3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/slo3.png" group-title="Slovenia",TV SLO 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=slo3&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=slo3
 
 ##	Koper
 ##	koper
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/koper.png" group-title="Slovenia",Koper
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=koper&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=koper
 
 ##	Maribor
 ##	maribor
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/maribor.png" group-title="Slovenia",Maribor
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=maribor&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=maribor
 
 ##	MMC
 ##	mmc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/mmc.png" group-title="Slovenia",MMC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=mmc&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=mmc
 
 
 
@@ -1776,167 +1766,167 @@ plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=m
 ##	ECTV
 ##	ectv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ectv.png" group-title="Ethiopia",ECTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ectv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ectv
 
 ##	Amhara TV
 ##	amma
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/amma.png" group-title="Ethiopia",Amhara TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=amma&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=amma
 
 ##	Fana TV
 ##	fbctv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/fbctv.png" group-title="Ethiopia",Fana TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=fbctv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=fbctv
 
 ##	Walta TV
 ##	walta
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/walta.png" group-title="Ethiopia",Walta TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=walta&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=walta
 
 ##	EBC ZENA
 ##	etvz
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/etvz.png" group-title="Ethiopia",EBC ZENA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=etvz&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=etvz
 
 ##	EBC MEZINAGNA
 ##	etvm
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/etvm.png" group-title="Ethiopia",EBC MEZINAGNA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=etvm&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=etvm
 
 ##	EBC QUANQUAWOCH
 ##	etvq
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/etvq.png" group-title="Ethiopia",EBC QUANQUAWOCH
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=etvq&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=etvq
 
 ##	LTV
 ##	ltv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ltv.png" group-title="Ethiopia",LTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ltv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ltv
 
 ##	ARTS TV
 ##	arts
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/arts.png" group-title="Ethiopia",ARTS TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arts&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=arts
 
 ##	MoE
 ##	moe
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/moe.png" group-title="Ethiopia",MoE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=moe&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=moe
 
 ##	Nahoo TV
 ##	nahoo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/nahoo.png" group-title="Ethiopia",Nahoo TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nahoo&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=nahoo
 
 ##	OBN
 ##	obn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/obn.png" group-title="Ethiopia",OBN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=obn&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=obn
 
 ##	OBS
 ##	obs
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/obs.png" group-title="Ethiopia",OBS
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=obs&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=obs
 
 ##	Tigrai TV
 ##	tigrai
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/tigrai.png" group-title="Ethiopia",Tigrai TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tigrai&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=tigrai
 
 ##	JTV ETHIOPIA
 ##	jtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/jtv.png" group-title="Ethiopia",JTV ETHIOPIA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=jtv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=jtv
 
 ##	ESAT
 ##	esat
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/esat.png" group-title="Ethiopia",ESAT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=esat&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=esat
 
 ##	OMN
 ##	omn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/omn.png" group-title="Ethiopia",OMN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=omn&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=omn
 
 ##	Aleph TV
 ##	aleph
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/aleph.png" group-title="Ethiopia",Aleph TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=aleph&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=aleph
 
 ##	Bisrat TV
 ##	bisrat
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/bisrat.png" group-title="Ethiopia",Bisrat TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bisrat&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=bisrat
 
 ##	ONN TV
 ##	onn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/onn.png" group-title="Ethiopia",ONN TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=onn&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=onn
 
 ##	DW TV
 ##	dws
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/dws.png" group-title="Ethiopia",DW TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dws&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=dws
 
 ##	Addis TV
 ##	adis
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/adis.png" group-title="Ethiopia",Addis TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=adis&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=adis
 
 ##	ES TV
 ##	estv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/estv.png" group-title="Ethiopia",ES TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=estv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=estv
 
 ##	Southern TV
 ##	south
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/south.png" group-title="Ethiopia",Southern TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=south&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=south
 
 ##	Eritrea TV
 ##	eritr
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/eritr.png" group-title="Ethiopia",Eritrea TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=eritr&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=eritr
 
 ##	Afrihealth
 ##	afri
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/afri.png" group-title="Ethiopia",Afrihealth
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=afri&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=afri
 
 ##	Asham TV
 ##	asham
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/asham.png" group-title="Ethiopia",Asham TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=asham&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=asham
 
 ##	Ahadu TV
 ##	ahadu
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ahadu.png" group-title="Ethiopia",Ahadu TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ahadu&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ahadu
 
 ##	Balageru
 ##	balage
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/balage.png" group-title="Ethiopia",Balageru
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=balage&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=balage
 
 ##	AVA TV
 ##	ava
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ava.png" group-title="Ethiopia",AVA TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ava&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ava
 
 ##	ASRAT MEDIA
 ##	asrat
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/asrat.png" group-title="Ethiopia",ASRAT MEDIA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=asrat&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=asrat
 
 ##	Holy Spirit TV
 ##	holys
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/holys.png" group-title="Ethiopia",Holy Spirit TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=holys&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=holys
 
 ##	Glory of GOD TV
 ##	gloryg
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/gloryg.png" group-title="Ethiopia",Glory of GOD TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=gloryg&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=gloryg
 
 
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_be.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_be.m3u
@@ -6,120 +6,120 @@
 ##	RTL-TVI
 ##	rtl_tvi
 #EXTINF:-1 tvg-id="C168.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtltvi.png" group-title="Belgium Belgique fr",RTL-TVI
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl_tvi&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=rtl_tvi
 
 ##	PLUG RTL
 ##	plug_rtl
 #EXTINF:-1 tvg-id="C377.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/plugrtl.png" group-title="Belgium Belgique fr",PLUG RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=plug_rtl&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=plug_rtl
 
 ##	CLUB RTL
 ##	club_rtl
 #EXTINF:-1 tvg-id="C50.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/clubrtl.png" group-title="Belgium Belgique fr",CLUB RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=club_rtl&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=club_rtl
 
 ##	Télé MB
 ##	telemb
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/telemb.png" group-title="Belgium Belgique fr",Télé MB
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telemb&item_module=resources.lib.channels.be.telemb
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/telemb/get_live_url/?item_id=telemb
 
 ##	RTC Télé Liège
 ##	rtc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtc.png" group-title="Belgium Belgique fr",RTC Télé Liège
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtc&item_module=resources.lib.channels.be.rtc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtc/get_live_url/?item_id=rtc
 
 ##	TV Lux
 ##	tvlux
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/tvlux.png" group-title="Belgium Belgique fr",TV Lux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvlux&item_module=resources.lib.channels.be.tvlux
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/tvlux/get_live_url/?item_id=tvlux
 
 ##	RTL INFO
 ##	rtl_info
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtlinfo.png" group-title="Belgium Belgique fr",RTL INFO
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl_info&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=rtl_info
 
 ##	BEL RTL
 ##	bel_rtl
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/belrtl.png" group-title="Belgium Belgique fr",BEL RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bel_rtl&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=bel_rtl
 
 ##	Contact
 ##	contact
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/contact.png" group-title="Belgium Belgique fr Radio",Contact
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=contact&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=contact
 
 ##	BX1
 ##	bx1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/bx1.png" group-title="Belgium Belgique fr",BX1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bx1&item_module=resources.lib.channels.be.bx1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/bx1/get_live_url/?item_id=bx1
 
 ##	Één
 ##	een
 #EXTINF:-1 tvg-id="C23.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/een.png" group-title="Belgium België nl",Één
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=een&item_module=resources.lib.channels.be.vrt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/vrt/get_live_url/?item_id=een
 
 ##	Canvas
 ##	canvas
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/canvas.png" group-title="Belgium België nl",Canvas
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=canvas&item_module=resources.lib.channels.be.vrt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/vrt/get_live_url/?item_id=canvas
 
 ##	Ketnet
 ##	ketnet
 #EXTINF:-1 tvg-id="C1280.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ketnet.png" group-title="Belgium België nl",Ketnet
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ketnet&item_module=resources.lib.channels.be.vrt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/vrt/get_live_url/?item_id=ketnet
 
 ##	NRJ Hits TV
 ##	nrjhitstvbe
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/nrjhitstvbe.png" group-title="Belgium Belgique fr",NRJ Hits TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nrjhitstvbe&item_module=resources.lib.channels.be.nrjhitstvbe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/nrjhitstvbe/get_live_url/?item_id=nrjhitstvbe
 
 ##	RTL Sport
 ##	rtl_sport
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/rtlsport.png" group-title="Belgium Belgique fr",RTL Sport
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl_sport&item_module=resources.lib.channels.be.rtlplaybe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtlplaybe/get_live_url/?item_id=rtl_sport
 
 ##	TV Com
 ##	tvcom
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/tvcom.png" group-title="Belgium Belgique fr",TV Com
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvcom&item_module=resources.lib.channels.be.tvcom
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/tvcom/get_live_url/?item_id=tvcom
 
 ##	Canal C
 ##	canalc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/canalc.png" group-title="Belgium Belgique fr",Canal C
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=canalc&item_module=resources.lib.channels.be.canalc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/canalc/get_live_url/?item_id=canalc
 
 ##	ABXPLORE
 ##	abxplore
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/abxplore.png" group-title="Belgium Belgique fr",ABXPLORE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=abxplore&item_module=resources.lib.channels.be.abbe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/abbe/get_live_url/?item_id=abxplore
 
 ##	AB3
 ##	ab3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ab3.png" group-title="Belgium Belgique fr",AB3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ab3&item_module=resources.lib.channels.be.abbe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/abbe/get_live_url/?item_id=ab3
 
 ##	LN24
 ##	ln24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ln24.png" group-title="Belgium Belgique fr",LN24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ln24&item_module=resources.lib.channels.be.ln24
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/ln24/get_live_url/?item_id=ln24
 
 ##	La Une
 ##	laune
 #EXTINF:-1 tvg-id="C164.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/laune.png" group-title="Belgium",La Une
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=laune&item_module=resources.lib.channels.be.rtbf
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf/set_live_url/?item_id=laune
 
 ##	La Deux
 ##	ladeux
 #EXTINF:-1 tvg-id="C187.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/ladeux.png" group-title="Belgium",La Deux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ladeux&item_module=resources.lib.channels.be.rtbf
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf/set_live_url/?item_id=ladeux
 
 ##	La Trois
 ##	latrois
 #EXTINF:-1 tvg-id="C892.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/latrois.png" group-title="Belgium",La Trois
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=latrois&item_module=resources.lib.channels.be.rtbf
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/rtbf/set_live_url/?item_id=latrois
 
 ##	Antenne Centre TV
 ##	actv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/be/actv.png" group-title="Belgium",Antenne Centre TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=actv&item_module=resources.lib.channels.be.actv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/be/actv/get_live_url/?item_id=actv
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_ca.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_ca.m3u
@@ -6,145 +6,145 @@
 ##	Télé-Québec
 ##	telequebec
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/telequebec.png" group-title="Canada",Télé-Québec
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telequebec&item_module=resources.lib.channels.ca.telequebec
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/telequebec/get_live_url/?item_id=telequebec
 
 ##	TVA
 ##	tva
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/tva.png" group-title="Canada",TVA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tva&item_module=resources.lib.channels.ca.tva
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/tva/get_live_url/?item_id=tva
 
 ##	ICI Télé Vancouver
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Vancouver
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Vancouver
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Vancouver
 
 ##	ICI Télé Regina
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Regina
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Regina
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Regina
 
 ##	ICI Télé Toronto
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Toronto
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Toronto
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Toronto
 
 ##	ICI Télé Edmonton
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Edmonton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Edmonton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Edmonton
 
 ##	ICI Télé Rimouski
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Rimouski
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Rimouski
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Rimouski
 
 ##	ICI Télé Québec
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Québec
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Qu%C3%A9bec
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Qu%C3%A9bec
 
 ##	ICI Télé Winnipeg
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Winnipeg
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Winnipeg
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Winnipeg
 
 ##	ICI Télé Moncton
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Moncton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Moncton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Moncton
 
 ##	ICI Télé Ottawa
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Ottawa
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Ottawa
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Ottawa
 
 ##	ICI Télé Montréal
 ##	icitele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/icitele.png" group-title="Canada",ICI Télé Montréal
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitele&item_module=resources.lib.channels.ca.icitele&language=Montr%C3%A9al
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/icitele/get_live_url/?item_id=icitele&language=Montr%C3%A9al
 
 ##	NTV
 ##	ntvca
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/ntvca.png" group-title="Canada",NTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ntvca&item_module=resources.lib.channels.ca.ntvca
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/ntvca/get_live_url/?item_id=ntvca
 
 ##	Télé-Mag
 ##	telemag
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/telemag.png" group-title="Canada",Télé-Mag
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telemag&item_module=resources.lib.channels.ca.telemag
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/telemag/get_live_url/?item_id=telemag
 
 ##	V Télé
 ##	vtele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/vtele.png" group-title="Canada",V Télé
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=vtele&item_module=resources.lib.channels.ca.noovo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/noovo/get_live_url/?item_id=vtele
 
 ##	CBC Ottawa
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Ottawa
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Ottawa
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Ottawa
 
 ##	CBC Montreal
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Montreal
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Montreal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Montreal
 
 ##	CBC Charlottetown
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Charlottetown
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Charlottetown
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Charlottetown
 
 ##	CBC Fredericton
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Fredericton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Fredericton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Fredericton
 
 ##	CBC Halifax
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Halifax
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Halifax
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Halifax
 
 ##	CBC Windsor
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Windsor
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Windsor
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Windsor
 
 ##	CBC Yellowknife
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Yellowknife
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Yellowknife
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Yellowknife
 
 ##	CBC Winnipeg
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Winnipeg
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Winnipeg
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Winnipeg
 
 ##	CBC Regina
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Regina
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Regina
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Regina
 
 ##	CBC Calgary
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Calgary
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Calgary
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Calgary
 
 ##	CBC Edmonton
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Edmonton
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Edmonton
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Edmonton
 
 ##	CBC Vancouver
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Vancouver
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Vancouver
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Vancouver
 
 ##	CBC Toronto
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC Toronto
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=Toronto
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=Toronto
 
 ##	CBC St. John's
 ##	cbc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ca/cbc.png" group-title="Canada",CBC St. John's
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbc&item_module=resources.lib.channels.ca.cbc&language=St.+John%27s
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ca/cbc/get_live_url/?item_id=cbc&language=St.+John%27s
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_ch.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_ch.m3u
@@ -6,85 +6,85 @@
 ##	Rouge TV
 ##	rougetv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rougetv.png" group-title="Switzerland",Rouge TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rougetv&item_module=resources.lib.channels.ch.rougetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/rougetv/get_live_url/?item_id=rougetv
 
 ##	TVM3
 ##	tvm3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/tvm3.png" group-title="Switzerland",TVM3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvm3&item_module=resources.lib.channels.ch.tvm3
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/tvm3/get_live_url/?item_id=tvm3
 
 ##	RTS Un
 ##	rtsun
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtsun.png" group-title="Switzerland",RTS Un
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtsun&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtsun
 
 ##	RTS Deux
 ##	rtsdeux
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtsdeux.png" group-title="Switzerland",RTS Deux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtsdeux&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtsdeux
 
 ##	RTS Info
 ##	rtsinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtsinfo.png" group-title="Switzerland",RTS Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtsinfo&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtsinfo
 
 ##	RTS Couleur 3
 ##	rtscouleur3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtscouleur3.png" group-title="Switzerland",RTS Couleur 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtscouleur3&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtscouleur3
 
 ##	RTS La 1
 ##	rsila1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rsila1.png" group-title="Switzerland",RTS La 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rsila1&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rsila1
 
 ##	RTS La 2
 ##	rsila2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rsila2.png" group-title="Switzerland",RTS La 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rsila2&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rsila2
 
 ##	SRF 1
 ##	srf1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/srf1.png" group-title="Switzerland",SRF 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=srf1&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=srf1
 
 ##	SRF Info
 ##	srfinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/srfinfo.png" group-title="Switzerland",SRF Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=srfinfo&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=srfinfo
 
 ##	SRF Zwei
 ##	srfzwei
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/srfzwei.png" group-title="Switzerland",SRF Zwei
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=srfzwei&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=srfzwei
 
 ##	RTR auf SRF 1
 ##	rtraufsrf1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtraufsrf1.png" group-title="Switzerland",RTR auf SRF 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtraufsrf1&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtraufsrf1
 
 ##	RTR auf SRF Info
 ##	rtraufsrfinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtraufsrfinfo.png" group-title="Switzerland",RTR auf SRF Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtraufsrfinfo&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtraufsrfinfo
 
 ##	RTR auf SRF 2
 ##	rtraufsrf2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/rtraufsrf2.png" group-title="Switzerland",RTR auf SRF 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtraufsrf2&item_module=resources.lib.channels.ch.srgssr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/srgssr/get_live_url/?item_id=rtraufsrf2
 
 ##	Teleticino
 ##	teleticino
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/teleticino.png" group-title="Switzerland",Teleticino
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=teleticino&item_module=resources.lib.channels.ch.teleticino
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/teleticino/get_live_url/?item_id=teleticino
 
 ##	Léman Bleu
 ##	lemanbleu
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/lemanbleu.png" group-title="Switzerland",Léman Bleu
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lemanbleu&item_module=resources.lib.channels.ch.lemanbleu
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/lemanbleu/get_live_url/?item_id=lemanbleu
 
 ##	Tele M1
 ##	telem1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/ch/telem1.png" group-title="Switzerland",Tele M1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telem1&item_module=resources.lib.channels.ch.telem1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/ch/telem1/get_live_url/?item_id=telem1
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_cm.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_cm.m3u
@@ -6,10 +6,10 @@
 ##	CRTV
 ##	crtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cm/crtv.png" group-title="Cameroon",CRTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=crtv&item_module=resources.lib.channels.cm.crtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cm/crtv/get_live_url/?item_id=crtv
 
 ##	CRTV News
 ##	crtvnews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cm/crtvnews.png" group-title="Cameroon",CRTV News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=crtvnews&item_module=resources.lib.channels.cm.crtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cm/crtv/get_live_url/?item_id=crtvnews
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_cn.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_cn.m3u
@@ -6,90 +6,90 @@
 ##	CCTV-1 综合
 ##	cctv1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv1.png" group-title="China",CCTV-1 综合
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv1&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv1
 
 ##	CCTV-2 财经
 ##	cctv2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv2.png" group-title="China",CCTV-2 财经
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv2&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv2
 
 ##	CCTV-3 综艺
 ##	cctv3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv3.png" group-title="China",CCTV-3 综艺
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv3&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv3
 
 ##	CCTV-4 中文国际（亚）
 ##	cctv4
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv4.png" group-title="China",CCTV-4 中文国际（亚）
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv4&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv4
 
 ##	CCTV-4 中文国际（欧）
 ##	cctveurope
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctveurope.png" group-title="China",CCTV-4 中文国际（欧）
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctveurope&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctveurope
 
 ##	CCTV-4 中文国际（美）
 ##	cctvamerica
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctvamerica.png" group-title="China",CCTV-4 中文国际（美）
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctvamerica&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctvamerica
 
 ##	CCTV-5 体育
 ##	cctv5
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv5.png" group-title="China",CCTV-5 体育
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv5&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv5
 
 ##	CCTV-5+ 体育赛事
 ##	cctv5plus
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv5plus.png" group-title="China",CCTV-5+ 体育赛事
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv5plus&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv5plus
 
 ##	CCTV-6 电影
 ##	cctv6
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv6.png" group-title="China",CCTV-6 电影
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv6&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv6
 
 ##	CCTV-7 军事农业
 ##	cctv7
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv7.png" group-title="China",CCTV-7 军事农业
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv7&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv7
 
 ##	CCTV-8 电视剧
 ##	cctv8
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv8.png" group-title="China",CCTV-8 电视剧
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv8&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv8
 
 ##	CCTV-9 纪录
 ##	cctvjilu
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctvjilu.png" group-title="China",CCTV-9 纪录
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctvjilu&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctvjilu
 
 ##	CCTV-10 科教
 ##	cctv10
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv10.png" group-title="China",CCTV-10 科教
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv10&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv10
 
 ##	CCTV-11 戏曲
 ##	cctv11
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv11.png" group-title="China",CCTV-11 戏曲
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv11&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv11
 
 ##	CCTV-12 社会与法
 ##	cctv12
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv12.png" group-title="China",CCTV-12 社会与法
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv12&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv12
 
 ##	CCTV-13 新闻
 ##	cctv13
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv13.png" group-title="China",CCTV-13 新闻
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv13&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv13
 
 ##	CCTV-14 少儿
 ##	cctvchild
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctvchild.png" group-title="China",CCTV-14 少儿
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctvchild&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctvchild
 
 ##	CCTV-15 音乐
 ##	cctv15
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/cn/cctv15.png" group-title="China",CCTV-15 音乐
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cctv15&item_module=resources.lib.channels.cn.cctv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/cn/cctv/get_live_url/?item_id=cctv15
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_es.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_es.m3u
@@ -6,75 +6,75 @@
 ##	Telecinco
 ##	telecinco
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/telecinco.png" group-title="Spain",Telecinco
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telecinco&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=telecinco
 
 ##	Cuatro
 ##	cuatro
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/cuatro.png" group-title="Spain",Cuatro
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cuatro&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=cuatro
 
 ##	Factoria de Ficcion
 ##	fdf
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/fdf.png" group-title="Spain",Factoria de Ficcion
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=fdf&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=fdf
 
 ##	Boing
 ##	boing
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/boing.png" group-title="Spain",Boing
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=boing&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=boing
 
 ##	Energy TV
 ##	energy
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/energy.png" group-title="Spain",Energy TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=energy&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=energy
 
 ##	Divinity
 ##	divinity
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/divinity.png" group-title="Spain",Divinity
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=divinity&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=divinity
 
 ##	Be Mad
 ##	bemad
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/bemad.png" group-title="Spain",Be Mad
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bemad&item_module=resources.lib.channels.es.mitele
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/mitele/get_live_url/?item_id=bemad
 
 ##	Realmadrid TV EN
 ##	realmadridtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/realmadridtv.png" group-title="Spain",Realmadrid TV EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=realmadridtv&item_module=resources.lib.channels.es.realmadridtv&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/realmadridtv/get_live_url/?item_id=realmadridtv&language=EN
 
 ##	Realmadrid TV ES
 ##	realmadridtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/realmadridtv.png" group-title="Spain",Realmadrid TV ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=realmadridtv&item_module=resources.lib.channels.es.realmadridtv&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/realmadridtv/get_live_url/?item_id=realmadridtv&language=ES
 
 ##	Paramount Channel (ES)
 ##	paramountchannel_es
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/es/paramountchannel_es.png" group-title="Spain",Paramount Channel (ES)
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=paramountchannel_es&item_module=resources.lib.channels.es.paramountchannel_es
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/es/paramountchannel_es/get_live_url/?item_id=paramountchannel_es
 
 ##	Euronews
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="Spain",Euronews
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=ES
 
 ##	France 24
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="Spain",France 24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=ES
 
 ##	DW
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="Spain",DW
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=ES
 
 ##	CGTN
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="Spain",CGTN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=ES
 
 ##	RT
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="Spain",RT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=ES
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_et.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_et.m3u
@@ -6,165 +6,165 @@
 ##	ECTV
 ##	ectv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ectv.png" group-title="Ethiopia",ECTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ectv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ectv
 
 ##	Amhara TV
 ##	amma
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/amma.png" group-title="Ethiopia",Amhara TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=amma&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=amma
 
 ##	Fana TV
 ##	fbctv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/fbctv.png" group-title="Ethiopia",Fana TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=fbctv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=fbctv
 
 ##	Walta TV
 ##	walta
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/walta.png" group-title="Ethiopia",Walta TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=walta&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=walta
 
 ##	EBC ZENA
 ##	etvz
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/etvz.png" group-title="Ethiopia",EBC ZENA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=etvz&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=etvz
 
 ##	EBC MEZINAGNA
 ##	etvm
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/etvm.png" group-title="Ethiopia",EBC MEZINAGNA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=etvm&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=etvm
 
 ##	EBC QUANQUAWOCH
 ##	etvq
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/etvq.png" group-title="Ethiopia",EBC QUANQUAWOCH
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=etvq&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=etvq
 
 ##	LTV
 ##	ltv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ltv.png" group-title="Ethiopia",LTV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ltv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ltv
 
 ##	ARTS TV
 ##	arts
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/arts.png" group-title="Ethiopia",ARTS TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arts&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=arts
 
 ##	MoE
 ##	moe
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/moe.png" group-title="Ethiopia",MoE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=moe&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=moe
 
 ##	Nahoo TV
 ##	nahoo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/nahoo.png" group-title="Ethiopia",Nahoo TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nahoo&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=nahoo
 
 ##	OBN
 ##	obn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/obn.png" group-title="Ethiopia",OBN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=obn&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=obn
 
 ##	OBS
 ##	obs
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/obs.png" group-title="Ethiopia",OBS
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=obs&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=obs
 
 ##	Tigrai TV
 ##	tigrai
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/tigrai.png" group-title="Ethiopia",Tigrai TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tigrai&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=tigrai
 
 ##	JTV ETHIOPIA
 ##	jtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/jtv.png" group-title="Ethiopia",JTV ETHIOPIA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=jtv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=jtv
 
 ##	ESAT
 ##	esat
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/esat.png" group-title="Ethiopia",ESAT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=esat&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=esat
 
 ##	OMN
 ##	omn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/omn.png" group-title="Ethiopia",OMN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=omn&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=omn
 
 ##	Aleph TV
 ##	aleph
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/aleph.png" group-title="Ethiopia",Aleph TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=aleph&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=aleph
 
 ##	Bisrat TV
 ##	bisrat
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/bisrat.png" group-title="Ethiopia",Bisrat TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bisrat&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=bisrat
 
 ##	ONN TV
 ##	onn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/onn.png" group-title="Ethiopia",ONN TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=onn&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=onn
 
 ##	DW TV
 ##	dws
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/dws.png" group-title="Ethiopia",DW TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dws&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=dws
 
 ##	Addis TV
 ##	adis
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/adis.png" group-title="Ethiopia",Addis TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=adis&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=adis
 
 ##	ES TV
 ##	estv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/estv.png" group-title="Ethiopia",ES TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=estv&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=estv
 
 ##	Southern TV
 ##	south
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/south.png" group-title="Ethiopia",Southern TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=south&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=south
 
 ##	Eritrea TV
 ##	eritr
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/eritr.png" group-title="Ethiopia",Eritrea TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=eritr&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=eritr
 
 ##	Afrihealth
 ##	afri
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/afri.png" group-title="Ethiopia",Afrihealth
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=afri&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=afri
 
 ##	Asham TV
 ##	asham
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/asham.png" group-title="Ethiopia",Asham TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=asham&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=asham
 
 ##	Ahadu TV
 ##	ahadu
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ahadu.png" group-title="Ethiopia",Ahadu TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ahadu&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ahadu
 
 ##	Balageru
 ##	balage
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/balage.png" group-title="Ethiopia",Balageru
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=balage&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=balage
 
 ##	AVA TV
 ##	ava
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/ava.png" group-title="Ethiopia",AVA TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ava&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=ava
 
 ##	ASRAT MEDIA
 ##	asrat
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/asrat.png" group-title="Ethiopia",ASRAT MEDIA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=asrat&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=asrat
 
 ##	Holy Spirit TV
 ##	holys
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/holys.png" group-title="Ethiopia",Holy Spirit TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=holys&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=holys
 
 ##	Glory of GOD TV
 ##	gloryg
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/et/gloryg.png" group-title="Ethiopia",Glory of GOD TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=gloryg&item_module=resources.lib.channels.et.video2b
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/et/video2b/get_live_url/?item_id=gloryg
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_fr.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_fr.m3u
@@ -6,565 +6,555 @@
 ##	TF1
 ##	tf1
 #EXTINF:-1 tvg-id="C192.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tf1.png" group-title="France TNT",TF1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tf1&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tf1
 
 ##	France 2
 ##	france-2
 #EXTINF:-1 tvg-id="C4.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france2.png" group-title="France TNT",France 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-2&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-2
 
 ##	France 3
 ##	france-3
 #EXTINF:-1 tvg-id="C80.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3.png" group-title="France TNT",France 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-3&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-3
 
 ##	Canal +
 ##	canalplus
 #EXTINF:-1 tvg-id="C34.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/canalplus.png" group-title="France TNT",Canal +
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=canalplus&item_module=resources.lib.channels.fr.mycanal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal/get_live_url/?item_id=canalplus
 
 ##	France 5
 ##	france-5
 #EXTINF:-1 tvg-id="C47.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france5.png" group-title="France TNT",France 5
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-5&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-5
 
 ##	M6
 ##	m6
 #EXTINF:-1 tvg-id="C118.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/m6.png" group-title="France TNT",M6
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=m6&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=m6
 
 ##	Arte
 ##	arte
 #EXTINF:-1 tvg-id="C111.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/arte.png" group-title="France TNT",Arte
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arte&item_module=resources.lib.channels.wo.arte&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/arte/get_live_url/?item_id=arte&language=FR
 
 ##	C8
 ##	c8
 #EXTINF:-1 tvg-id="C445.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/c8.png" group-title="France TNT",C8
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=c8&item_module=resources.lib.channels.fr.mycanal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal/get_live_url/?item_id=c8
 
 ##	W9
 ##	w9
 #EXTINF:-1 tvg-id="C119.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/w9.png" group-title="France TNT",W9
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=w9&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=w9
 
 ##	TMC
 ##	tmc
 #EXTINF:-1 tvg-id="C195.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tmc.png" group-title="France TNT",TMC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tmc&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tmc
 
 ##	TFX
 ##	tfx
 #EXTINF:-1 tvg-id="C446.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tfx.png" group-title="France TNT",TFX
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tfx&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tfx
 
 ##	NRJ 12
 ##	nrj12
 #EXTINF:-1 tvg-id="C444.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/nrj12.png" group-title="France TNT",NRJ 12
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nrj12&item_module=resources.lib.channels.fr.nrj
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/nrj/get_live_url/?item_id=nrj12
 
 ##	LCP Assemblée Nationale
 ##	lcp
 #EXTINF:-1 tvg-id="C234.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lcp.png" group-title="France TNT",LCP Assemblée Nationale
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lcp&item_module=resources.lib.channels.fr.lcp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lcp/get_live_url/?item_id=lcp
 
 ##	Public Sénat
 ##	publicsenat
 #EXTINF:-1 tvg-id="C234.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/publicsenat.png" group-title="France TNT",Public Sénat
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=publicsenat&item_module=resources.lib.channels.fr.publicsenat
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/publicsenat/get_live_url/?item_id=publicsenat
 
 ##	France 4
 ##	france-4
 #EXTINF:-1 tvg-id="C78.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france4.png" group-title="France TNT",France 4
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-4&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-4
 
 ##	BFM TV
 ##	bfmtv
 #EXTINF:-1 tvg-id="C481.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmtv.png" group-title="France TNT",BFM TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmtv&item_module=resources.lib.channels.fr.bfmtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmtv/get_live_url/?item_id=bfmtv
 
 ##	CNews
 ##	cnews
 #EXTINF:-1 tvg-id="C226.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/cnews.png" group-title="France TNT",CNews
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cnews&item_module=resources.lib.channels.fr.cnews
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/cnews/get_live_url/?item_id=cnews
 
 ##	CStar
 ##	cstar
 #EXTINF:-1 tvg-id="C458.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/cstar.png" group-title="France TNT",CStar
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cstar&item_module=resources.lib.channels.fr.mycanal
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mycanal/get_live_url/?item_id=cstar
 
 ##	Gulli
 ##	gulli
 #EXTINF:-1 tvg-id="C482.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/gulli.png" group-title="France TNT",Gulli
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=gulli&item_module=resources.lib.channels.fr.gulli
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/gulli/get_live_url/?item_id=gulli
 
 ##	France Ô
 ##	france-o
 #EXTINF:-1 tvg-id="C160.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/franceo.png" group-title="France TNT",France Ô
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france-o&item_module=resources.lib.channels.fr.francetv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/francetv/get_live_url/?item_id=france-o
 
 ##	TF1 Séries Films
 ##	tf1-series-films
 #EXTINF:-1 tvg-id="C1404.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tf1seriesfilms.png" group-title="France TNT",TF1 Séries Films
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tf1-series-films&item_module=resources.lib.channels.fr.mytf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/mytf1/get_live_url/?item_id=tf1-series-films
 
 ##	L'Équipe
 ##	lequipe
 #EXTINF:-1 tvg-id="C1401.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lequipe.png" group-title="France TNT",L'Équipe
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lequipe&item_module=resources.lib.channels.fr.lequipe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lequipe/get_live_url/?item_id=lequipe
 
 ##	6ter
 ##	6ter
 #EXTINF:-1 tvg-id="C1403.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/6ter.png" group-title="France TNT",6ter
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=6ter&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=6ter
 
 ##	RMC Story
 ##	rmcstory
 #EXTINF:-1 tvg-id="C1402.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rmcstory.png" group-title="France TNT",RMC Story
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rmcstory&item_module=resources.lib.channels.fr.rmc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/rmc/get_live_url/?item_id=rmcstory
 
 ##	RMC Découverte
 ##	rmcdecouverte
 #EXTINF:-1 tvg-id="C1400.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rmcdecouverte.png" group-title="France TNT",RMC Découverte
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rmcdecouverte&item_module=resources.lib.channels.fr.rmc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/rmc/get_live_url/?item_id=rmcdecouverte
 
 ##	Chérie 25
 ##	cherie25
 #EXTINF:-1 tvg-id="C1399.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/cherie25.png" group-title="France TNT",Chérie 25
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cherie25&item_module=resources.lib.channels.fr.nrj
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/nrj/get_live_url/?item_id=cherie25
 
 ##	LCI
 ##	lci
 #EXTINF:-1 tvg-id="C112.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lci.png" group-title="France TNT",LCI
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lci&item_module=resources.lib.channels.fr.lci
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lci/get_live_url/?item_id=lci
 
 ##	France Info
 ##	franceinfo
 #EXTINF:-1 tvg-id="C2111.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/franceinfo.png" group-title="France TNT",France Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=franceinfo&item_module=resources.lib.channels.fr.franceinfo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinfo/get_live_url/?item_id=franceinfo
 
 ##	La 1ère Guadeloupe
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Guadeloupe
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Guadeloupe
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Guadeloupe
 
 ##	La 1ère Guyane
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Guyane
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Guyane
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Guyane
 
 ##	La 1ère Martinique
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Martinique
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Martinique
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Martinique
 
 ##	La 1ère Mayotte
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Mayotte
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Mayotte
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Mayotte
 
 ##	La 1ère Nouvelle Calédonie
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Nouvelle Calédonie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Nouvelle+Cal%C3%A9donie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Nouvelle+Cal%C3%A9donie
 
 ##	La 1ère Polynésie
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Polynésie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Polyn%C3%A9sie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Polyn%C3%A9sie
 
 ##	La 1ère Réunion
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Réunion
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=R%C3%A9union
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=R%C3%A9union
 
 ##	La 1ère St-Pierre et Miquelon
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère St-Pierre et Miquelon
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=St-Pierre+et+Miquelon
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=St-Pierre+et+Miquelon
 
 ##	La 1ère Wallis et Futuna
 ##	la_1ere
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/la1ere.png" group-title="France Région",La 1ère Wallis et Futuna
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la_1ere&item_module=resources.lib.channels.fr.la_1ere&language=Wallis+et+Futuna
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/la_1ere/get_live_url/?item_id=la_1ere&language=Wallis+et+Futuna
 
 ##	BFM Business
 ##	bfmbusiness
 #EXTINF:-1 tvg-id="C1073.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmbusiness.png" group-title="France Satellite/FAI",BFM Business
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmbusiness&item_module=resources.lib.channels.fr.bfmtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmtv/get_live_url/?item_id=bfmbusiness
 
 ##	France 3 Régions Alpes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Alpes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Alpes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Alpes
 
 ##	France 3 Régions Alsace
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Alsace
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Alsace
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Alsace
 
 ##	France 3 Régions Aquitaine
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Aquitaine
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Aquitaine
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Aquitaine
 
 ##	France 3 Régions Auvergne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Auvergne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Auvergne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Auvergne
 
 ##	France 3 Régions Bourgogne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Bourgogne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Bourgogne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Bourgogne
 
 ##	France 3 Régions Bretagne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Bretagne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Bretagne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Bretagne
 
 ##	France 3 Régions Centre-Val de Loire
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Centre-Val de Loire
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Centre-Val+de+Loire
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Centre-Val+de+Loire
 
 ##	France 3 Régions Chapagne-Ardenne
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Chapagne-Ardenne
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Chapagne-Ardenne
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Chapagne-Ardenne
 
 ##	France 3 Régions Corse
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Corse
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Corse
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Corse
 
 ##	France 3 Régions Côte d'Azur
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Côte d'Azur
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=C%C3%B4te+d%27Azur
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=C%C3%B4te+d%27Azur
 
 ##	France 3 Régions Franche-Comté
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Franche-Comté
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Franche-Comt%C3%A9
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Franche-Comt%C3%A9
 
 ##	France 3 Régions Languedoc-Roussillon
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Languedoc-Roussillon
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Languedoc-Roussillon
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Languedoc-Roussillon
 
 ##	France 3 Régions Limousin
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Limousin
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Limousin
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Limousin
 
 ##	France 3 Régions Lorraine
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Lorraine
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Lorraine
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Lorraine
 
 ##	France 3 Régions Midi-Pyrénées
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Midi-Pyrénées
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Midi-Pyr%C3%A9n%C3%A9es
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Midi-Pyr%C3%A9n%C3%A9es
 
 ##	France 3 Régions Nord-Pas-de-Calais
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Nord-Pas-de-Calais
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Nord-Pas-de-Calais
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Nord-Pas-de-Calais
 
 ##	France 3 Régions Basse-Normandie
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Basse-Normandie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Basse-Normandie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Basse-Normandie
 
 ##	France 3 Régions Haute-Normandie
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Haute-Normandie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Haute-Normandie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Haute-Normandie
 
 ##	France 3 Régions Paris Île-de-France
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Paris Île-de-France
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Paris+%C3%8Ele-de-France
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Paris+%C3%8Ele-de-France
 
 ##	France 3 Régions Pays de la Loire
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Pays de la Loire
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Pays+de+la+Loire
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Pays+de+la+Loire
 
 ##	France 3 Régions Picardie
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Picardie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Picardie
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Picardie
 
 ##	France 3 Régions Poitou-Charentes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Poitou-Charentes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Poitou-Charentes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Poitou-Charentes
 
 ##	France 3 Régions Provence-Alpes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Provence-Alpes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Provence-Alpes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Provence-Alpes
 
 ##	France 3 Régions Rhône-Alpes
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Rhône-Alpes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Rh%C3%B4ne-Alpes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Rh%C3%B4ne-Alpes
 
 ##	France 3 Régions Nouvelle-Aquitaine
 ##	france3regions
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/france3regions.png" group-title="France Région",France 3 Régions Nouvelle-Aquitaine
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france3regions&item_module=resources.lib.channels.fr.france3regions&language=Nouvelle-Aquitaine
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/france3regions/get_live_url/?item_id=france3regions&language=Nouvelle-Aquitaine
 
 ##	Gong
 ##	gong
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/gong.png" group-title="France Satellite/FAI",Gong
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=gong&item_module=resources.lib.channels.fr.gong
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/gong/get_live_url/?item_id=gong
 
 ##	BFM Paris
 ##	bfmparis
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmparis.png" group-title="France Région",BFM Paris
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmparis&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmparis
 
 ##	Fun Radio
 ##	fun_radio
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/funradio.png" group-title="France Radio",Fun Radio
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=fun_radio&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=fun_radio
 
 ##	KTO
 ##	kto
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/kto.png" group-title="France Satellite/FAI",KTO
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=kto&item_module=resources.lib.channels.fr.kto
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/kto/get_live_url/?item_id=kto
 
 ##	Antenne Réunion
 ##	antennereunion
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/antennereunion.png" group-title="France Région",Antenne Réunion
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=antennereunion&item_module=resources.lib.channels.fr.antennereunion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/antennereunion/get_live_url/?item_id=antennereunion
 
 ##	viàOccitanie
 ##	viaoccitanie
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viaoccitanie.png" group-title="France Région",viàOccitanie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viaoccitanie&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viaoccitanie
 
 ##	Ouatch TV
 ##	ouatchtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/ouatchtv.png" group-title="France Satellite/FAI",Ouatch TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ouatchtv&item_module=resources.lib.channels.fr.ouatchtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/ouatchtv/get_live_url/?item_id=ouatchtv
 
 ##	RTL 2
 ##	rtl2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rtl2.png" group-title="France Radio",RTL 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl2&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=rtl2
 
 ##	viàATV
 ##	viaatv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viaatv.png" group-title="France Région",viàATV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viaatv&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viaatv
 
 ##	viàGrandParis
 ##	viagrandparis
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viagrandparis.png" group-title="France Région",viàGrandParis
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viagrandparis&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viagrandparis
 
 ##	Tébéo
 ##	tebeo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tebeo.png" group-title="France Région",Tébéo
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tebeo&item_module=resources.lib.channels.fr.tebeo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tebeo/get_live_url/?item_id=tebeo
 
 ##	M6 Boutique
 ##	mb
 #EXTINF:-1 tvg-id="C184.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/mb.png" group-title="France Satellite/FAI",M6 Boutique
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=mb&item_module=resources.lib.channels.fr.6play
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/6play/get_live_url/?item_id=mb
 
 ##	viàLMTv Sarthe
 ##	vialmtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/vialmtv.png" group-title="France Région",viàLMTv Sarthe
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=vialmtv&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=vialmtv
 
 ##	viàMirabelle
 ##	viamirabelle
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viamirabelle.png" group-title="France Région",viàMirabelle
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viamirabelle&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viamirabelle
 
 ##	viàVosges
 ##	viavosges
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viavosges.png" group-title="France Région",viàVosges
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viavosges&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viavosges
 
 ##	Télévision Loire 7
 ##	tl7
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tl7.png" group-title="France Région",Télévision Loire 7
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tl7&item_module=resources.lib.channels.fr.tl7
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tl7/get_live_url/?item_id=tl7
 
 ##	Lucky Jack
 ##	luckyjack
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/luckyjack.png" group-title="France Satellite/FAI",Lucky Jack
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=luckyjack&item_module=resources.lib.channels.fr.abweb
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/abweb/get_live_url/?item_id=luckyjack
 
 ##	8 Mont-Blanc
 ##	tv8montblanc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tv8montblanc.png" group-title="France Région",8 Mont-Blanc
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv8montblanc&item_module=resources.lib.channels.fr.tv8montblanc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tv8montblanc/get_live_url/?item_id=tv8montblanc
 
 ##	Alsace 20
 ##	alsace20
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/alsace20.png" group-title="France Région",Alsace 20
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=alsace20&item_module=resources.lib.channels.fr.alsace20
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/alsace20/get_live_url/?item_id=alsace20
 
 ##	TVPI télévision d'ici
 ##	tvpifr
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvpifr.png" group-title="France Région",TVPI télévision d'ici
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvpifr&item_module=resources.lib.channels.fr.tvpifr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvpifr/get_live_url/?item_id=tvpifr
 
 ##	IDF 1
 ##	idf1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/idf1.png" group-title="France Région",IDF 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=idf1&item_module=resources.lib.channels.fr.idf1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/idf1/get_live_url/?item_id=idf1
 
 ##	Azur TV
 ##	azurtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/azurtv.png" group-title="France Région",Azur TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=azurtv&item_module=resources.lib.channels.fr.azurtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/azurtv/get_live_url/?item_id=azurtv
 
 ##	BIP TV
 ##	biptv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/biptv.png" group-title="France Région",BIP TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=biptv&item_module=resources.lib.channels.fr.biptv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/biptv/get_live_url/?item_id=biptv
 
 ##	BFM Lille
 ##	bfmlille
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmlille.png" group-title="France Région",BFM Lille
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmlille&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmlille
 
 ##	BFM Littoral
 ##	bfmgrandlittoral
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmgrandlittoral.png" group-title="France Région",BFM Littoral
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmgrandlittoral&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmgrandlittoral
 
 ##	La Chaine Normande
 ##	lachainenormande
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/lachainenormande.png" group-title="France Région",La Chaine Normande
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=lachainenormande&item_module=resources.lib.channels.fr.lachainenormande
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/lachainenormande/get_live_url/?item_id=lachainenormande
 
 ##	Sport en France
 ##	sportenfrance
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/sportenfrance.png" group-title="France Satellite/FAI",Sport en France
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=sportenfrance&item_module=resources.lib.channels.fr.sportenfrance
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/sportenfrance/get_live_url/?item_id=sportenfrance
 
 ##	Provence Azur TV
 ##	provenceazurtv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/provenceazurtv.png" group-title="France Région",Provence Azur TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=provenceazurtv&item_module=resources.lib.channels.fr.azurtv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/azurtv/get_live_url/?item_id=provenceazurtv
 
 ##	TébéSud
 ##	tebesud
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tebesud.png" group-title="France Région",TébéSud
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tebesud&item_module=resources.lib.channels.fr.tebeo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tebeo/get_live_url/?item_id=tebesud
 
 ##	TéléGrenoble
 ##	telegrenoble
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/telegrenoble.png" group-title="France Région",TéléGrenoble
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telegrenoble&item_module=resources.lib.channels.fr.telegrenoble
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/telegrenoble/get_live_url/?item_id=telegrenoble
 
 ##	TéléNantes
 ##	telenantes
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/telenantes.png" group-title="France Région",TéléNantes
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=telenantes&item_module=resources.lib.channels.fr.telenantes
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/telenantes/get_live_url/?item_id=telenantes
 
 ##	BFM Lyon
 ##	bfmlyon
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bfmlyon.png" group-title="France Région",BFM Lyon
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bfmlyon&item_module=resources.lib.channels.fr.bfmregion
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/bfmregion/get_live_url/?item_id=bfmlyon
 
 ##	TLC
 ##	tlc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tlc.png" group-title="France Région",TLC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tlc&item_module=resources.lib.channels.fr.tlc
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tlc/get_live_url/?item_id=tlc
 
 ##	TV Vendée
 ##	tvvendee
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvvendee.png" group-title="France Région",TV Vendée
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvvendee&item_module=resources.lib.channels.fr.tvvendee
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvvendee/get_live_url/?item_id=tvvendee
 
 ##	TV7 Bordeaux
 ##	tv7bordeaux
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tv7bordeaux.png" group-title="France Région",TV7 Bordeaux
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv7bordeaux&item_module=resources.lib.channels.fr.tv7bordeaux
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tv7bordeaux/get_live_url/?item_id=tv7bordeaux
 
 ##	TVT Val de Loire
 ##	tvt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvt.png" group-title="France Région",TVT Val de Loire
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvt&item_module=resources.lib.channels.fr.tvt
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvt/get_live_url/?item_id=tvt
 
 ##	TVR
 ##	tvr
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/tvr.png" group-title="France Région",TVR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvr&item_module=resources.lib.channels.fr.tvr
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/tvr/get_live_url/?item_id=tvr
 
 ##	Wéo TV
 ##	weo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/weo.png" group-title="France Région",Wéo TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=weo&item_module=resources.lib.channels.fr.weo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/weo/get_live_url/?item_id=weo
 
 ##	DiCi TV
 ##	dicitv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/dicitv.png" group-title="France Région",DiCi TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dicitv&item_module=resources.lib.channels.fr.dicitv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/dicitv/get_live_url/?item_id=dicitv
 
 ##	viàMaTélé
 ##	viamatele
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/viamatele.png" group-title="France Région",viàMaTélé
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=viamatele&item_module=resources.lib.channels.fr.via
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/via/get_live_url/?item_id=viamatele
 
 ##	France Inter
 ##	franceinter
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/franceinter.png" group-title="France Radio",France Inter
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=franceinter&item_module=resources.lib.channels.fr.franceinter
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/franceinter/get_live_url/?item_id=franceinter
 
 ##	RTL
 ##	rtl
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/rtl.png" group-title="France Radio",RTL
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rtl&item_module=resources.lib.channels.fr.rtl
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/rtl/get_live_url/?item_id=rtl
 
 ##	Europe 1
 ##	europe1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/europe1.png" group-title="France Radio",Europe 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=europe1&item_module=resources.lib.channels.fr.europe1
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/europe1/get_live_url/?item_id=europe1
 
 ##	01Net TV
 ##	01net
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/01net.png" group-title="France Satellite/FAI",01Net TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=01net&item_module=resources.lib.channels.fr.01net
-
-##	Equidia
-##	equidia
-#EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/equidia.png" group-title="France Satellite/FAI",Equidia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=equidia&item_module=resources.lib.channels.fr.equidia
-
-##	B Smart
-##	bsmart
-#EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/fr/bsmart.png" group-title="France Satellite/FAI",B Smart
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bsmart&item_module=resources.lib.channels.fr.bsmart
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/fr/01net/get_live_url/?item_id=01net
 
 ##	Euronews
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="France",Euronews
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=FR
 
 ##	France 24
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="France",France 24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=FR
 
 ##	CGTN
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="France",CGTN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=FR
 
 ##	RT
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="France",RT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=FR
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_it.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_it.m3u
@@ -6,85 +6,85 @@
 ##	La7
 ##	la7
 #EXTINF:-1 tvg-id="www.la7.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/la7.png" group-title="Italia",La7
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=la7&item_module=resources.lib.channels.it.la7
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/la7/get_live_url/?item_id=la7
 
 ##	Rai News 24
 ##	rainews24
 #EXTINF:-1 tvg-id="rainews.guidatv.sky.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rainews24.png" group-title="Italia",Rai News 24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rainews24&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rainews24
 
 ##	Rai 1
 ##	rai1
 #EXTINF:-1 tvg-id="www.raiuno.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai1.png" group-title="Italia",Rai 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai1&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai1
 
 ##	Rai 2
 ##	rai2
 #EXTINF:-1 tvg-id="www.raidue.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai2.png" group-title="Italia",Rai 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai2&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai2
 
 ##	Rai 3
 ##	rai3
 #EXTINF:-1 tvg-id="www.raitre.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai3.png" group-title="Italia",Rai 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai3&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai3
 
 ##	Rai 4
 ##	rai4
 #EXTINF:-1 tvg-id="rai4.raisat.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai4.png" group-title="Italia",Rai 4
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai4&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai4
 
 ##	Rai 5
 ##	rai5
 #EXTINF:-1 tvg-id="rai5.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/rai5.png" group-title="Italia",Rai 5
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rai5&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=rai5
 
 ##	Rai Sport
 ##	raisportpiuhd
 #EXTINF:-1 tvg-id="raisport.guidatv.sky.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raisportpiuhd.png" group-title="Italia",Rai Sport
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raisportpiuhd&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raisportpiuhd
 
 ##	Rai Movie
 ##	raimovie
 #EXTINF:-1 tvg-id="raimovie.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raimovie.png" group-title="Italia",Rai Movie
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raimovie&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raimovie
 
 ##	Rai Premium
 ##	raipremium
 #EXTINF:-1 tvg-id="raipremium.guidatv.sky.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raipremium.png" group-title="Italia",Rai Premium
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raipremium&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raipremium
 
 ##	Rai Yoyo
 ##	raiyoyo
 #EXTINF:-1 tvg-id="yoyo.raisat.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raiyoyo.png" group-title="Italia",Rai Yoyo
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raiyoyo&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raiyoyo
 
 ##	Rai Gulp
 ##	raigulp
 #EXTINF:-1 tvg-id="raigulp.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raigulp.png" group-title="Italia",Rai Gulp
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raigulp&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raigulp
 
 ##	Rai Storia
 ##	raistoria
 #EXTINF:-1 tvg-id="raistoria.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raistoria.png" group-title="Italia",Rai Storia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raistoria&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raistoria
 
 ##	Rai Scuola
 ##	raiscuola
 #EXTINF:-1 tvg-id="raiscuola.rai.it" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/raiscuola.png" group-title="Italia",Rai Scuola
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=raiscuola&item_module=resources.lib.channels.it.raiplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/raiplay/get_live_url/?item_id=raiscuola
 
 ##	Paramount Channel (IT)
 ##	paramountchannel_it
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/it/paramountchannel_it.png" group-title="Italia",Paramount Channel (IT)
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=paramountchannel_it&item_module=resources.lib.channels.it.paramountchannel_it
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/it/paramountchannel_it/get_live_url/?item_id=paramountchannel_it
 
 ##	Euronews
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="Italia",Euronews
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=IT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=IT
 
 ##	QVC
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="Italia",QVC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=IT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=IT
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_jp.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_jp.m3u
@@ -6,20 +6,20 @@
 ##	日テレ News24
 ##	ntvnews24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/jp/ntvnews24.png" group-title="Japan",日テレ News24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=ntvnews24&item_module=resources.lib.channels.jp.ntvnews24
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/jp/ntvnews24/get_live_url/?item_id=ntvnews24
 
 ##	ジャパネットチャンネルDX
 ##	japanetshoppingdx
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/jp/japanetshoppingdx.png" group-title="Japan",ジャパネットチャンネルDX
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=japanetshoppingdx&item_module=resources.lib.channels.jp.japanetshoppingdx
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/jp/japanetshoppingdx/get_live_url/?item_id=japanetshoppingdx
 
 ##	株式会社ウェザーニューズ
 ##	weathernewsjp
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/jp/weathernewsjp.png" group-title="Japan",株式会社ウェザーニューズ
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=weathernewsjp&item_module=resources.lib.channels.jp.weathernewsjp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/jp/weathernewsjp/get_live_url/?item_id=weathernewsjp
 
 ##	QVC
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="Japan",QVC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=JP
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=JP
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_nl.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_nl.m3u
@@ -6,45 +6,45 @@
 ##	NPO 1
 ##	npo-1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo1.png" group-title="Netherlands",NPO 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-1&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-1
 
 ##	NPO 2
 ##	npo-2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo2.png" group-title="Netherlands",NPO 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-2&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-2
 
 ##	NPO 3
 ##	npo-3zapp
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npozapp.png" group-title="Netherlands",NPO 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-3zapp&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-3zapp
 
 ##	NPO 1 Extra
 ##	npo-1-extra
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo1extra.png" group-title="Netherlands",NPO 1 Extra
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-1-extra&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-1-extra
 
 ##	NPO 2 Extra
 ##	npo-2-extra
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npo2extra.png" group-title="Netherlands",NPO 2 Extra
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-2-extra&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-2-extra
 
 ##	NPO Zappelin Extra
 ##	npo-zappelin-extra
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npozappelinextra.png" group-title="Netherlands",NPO Zappelin Extra
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-zappelin-extra&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-zappelin-extra
 
 ##	NPO Nieuws
 ##	npo-nieuws
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/nponieuws.png" group-title="Netherlands",NPO Nieuws
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-nieuws&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-nieuws
 
 ##	NPO Politiek
 ##	npo-politiek
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/npopolitiek.png" group-title="Netherlands",NPO Politiek
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=npo-politiek&item_module=resources.lib.channels.nl.npo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/npo/get_live_url/?item_id=npo-politiek
 
 ##	AT5
 ##	at5
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/nl/at5.png" group-title="Netherlands",AT5
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=at5&item_module=resources.lib.channels.nl.at5
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/nl/at5/get_live_url/?item_id=at5
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_pl.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_pl.m3u
@@ -6,95 +6,95 @@
 ##	TVP 3 Białystok
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Białystok
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Bia%C5%82ystok
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Bia%C5%82ystok
 
 ##	TVP 3 Bydgoszcz
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Bydgoszcz
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Bydgoszcz
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Bydgoszcz
 
 ##	TVP 3 Gdańsk
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Gdańsk
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Gda%C5%84sk
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Gda%C5%84sk
 
 ##	TVP 3 Gorzów Wielkopolski
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Gorzów Wielkopolski
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Gorz%C3%B3w+Wielkopolski
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Gorz%C3%B3w+Wielkopolski
 
 ##	TVP 3 Katowice
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Katowice
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Katowice
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Katowice
 
 ##	TVP 3 Kielce
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Kielce
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Kielce
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Kielce
 
 ##	TVP 3 Kraków
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Kraków
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Krak%C3%B3w
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Krak%C3%B3w
 
 ##	TVP 3 Lublin
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Lublin
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Lublin
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Lublin
 
 ##	TVP 3 Łódź
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Łódź
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=%C5%81%C3%B3d%C5%BA
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=%C5%81%C3%B3d%C5%BA
 
 ##	TVP 3 Olsztyn
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Olsztyn
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Olsztyn
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Olsztyn
 
 ##	TVP 3 Opole
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Opole
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Opole
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Opole
 
 ##	TVP 3 Poznań
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Poznań
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Pozna%C5%84
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Pozna%C5%84
 
 ##	TVP 3 Rzeszów
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Rzeszów
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Rzesz%C3%B3w
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Rzesz%C3%B3w
 
 ##	TVP 3 Szczecin
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Szczecin
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Szczecin
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Szczecin
 
 ##	TVP 3 Warszawa
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Warszawa
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Warszawa
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Warszawa
 
 ##	TVP 3 Wrocław
 ##	tvp3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvp3.png" group-title="Poland",TVP 3 Wrocław
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvp3&item_module=resources.lib.channels.pl.tvp&language=Wroc%C5%82aw
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvp3&language=Wroc%C5%82aw
 
 ##	TVP Info
 ##	tvpinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvpinfo.png" group-title="Poland",TVP Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvpinfo&item_module=resources.lib.channels.pl.tvp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvpinfo
 
 ##	TVP Polonia
 ##	tvppolonia
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvppolonia.png" group-title="Poland",TVP Polonia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvppolonia&item_module=resources.lib.channels.pl.tvp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvppolonia
 
 ##	TVP Poland IN
 ##	tvppolandin
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/pl/tvppolandin.png" group-title="Poland",TVP Poland IN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tvppolandin&item_module=resources.lib.channels.pl.tvp
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/pl/tvp/get_live_url/?item_id=tvppolandin
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_si.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_si.m3u
@@ -6,30 +6,30 @@
 ##	TV SLO 1
 ##	slo1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/slo1.png" group-title="Slovenia",TV SLO 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=slo1&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=slo1
 
 ##	TV SLO 2
 ##	slo2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/slo2.png" group-title="Slovenia",TV SLO 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=slo2&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=slo2
 
 ##	TV SLO 3
 ##	slo3
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/slo3.png" group-title="Slovenia",TV SLO 3
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=slo3&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=slo3
 
 ##	Koper
 ##	koper
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/koper.png" group-title="Slovenia",Koper
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=koper&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=koper
 
 ##	Maribor
 ##	maribor
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/maribor.png" group-title="Slovenia",Maribor
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=maribor&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=maribor
 
 ##	MMC
 ##	mmc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/si/mmc.png" group-title="Slovenia",MMC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=mmc&item_module=resources.lib.channels.si.rtvslo
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/si/rtvslo/get_live_url/?item_id=mmc
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_tn.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_tn.m3u
@@ -6,15 +6,15 @@
 ##	التلفزة التونسية الوطنية 1
 ##	watania1
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/tn/watania1.png" group-title="Tunisia",التلفزة التونسية الوطنية 1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=watania1&item_module=resources.lib.channels.tn.watania
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/tn/watania/get_live_url/?item_id=watania1
 
 ##	التلفزة التونسية الوطنية 2
 ##	watania2
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/tn/watania2.png" group-title="Tunisia",التلفزة التونسية الوطنية 2
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=watania2&item_module=resources.lib.channels.tn.watania
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/tn/watania/get_live_url/?item_id=watania2
 
 ##	نسمة تي في
 ##	nessma
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/tn/nessma.png" group-title="Tunisia",نسمة تي في
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nessma&item_module=resources.lib.channels.tn.nessma
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/tn/nessma/get_live_url/?item_id=nessma
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_uk.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_uk.m3u
@@ -6,115 +6,115 @@
 ##	Blaze
 ##	blaze
 #EXTINF:-1 tvg-id="1013.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/blaze.png" group-title="United Kingdom",Blaze
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=blaze&item_module=resources.lib.channels.uk.blaze
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/blaze/get_live_url/?item_id=blaze
 
 ##	Dave
 ##	dave
 #EXTINF:-1 tvg-id="432.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/dave.png" group-title="United Kingdom",Dave
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dave&item_module=resources.lib.channels.uk.uktvplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay/get_live_url/?item_id=dave
 
 ##	Yesterday
 ##	yesterday
 #EXTINF:-1 tvg-id="320.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/yesterday.png" group-title="United Kingdom",Yesterday
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=yesterday&item_module=resources.lib.channels.uk.uktvplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay/get_live_url/?item_id=yesterday
 
 ##	Drama
 ##	drama
 #EXTINF:-1 tvg-id="871.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/drama.png" group-title="United Kingdom",Drama
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=drama&item_module=resources.lib.channels.uk.uktvplay
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/uktvplay/get_live_url/?item_id=drama
 
 ##	Sky News
 ##	skynews
 #EXTINF:-1 tvg-id="257.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/skynews.png" group-title="United Kingdom",Sky News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=skynews&item_module=resources.lib.channels.uk.sky
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/sky/get_live_url/?item_id=skynews
 
 ##	STV
 ##	stv
 #EXTINF:-1 tvg-id="178.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/stv.png" group-title="United Kingdom",STV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=stv&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=stv
 
 ##	Kerrang
 ##	kerrang
 #EXTINF:-1 tvg-id="1207.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/kerrang.png" group-title="United Kingdom",Kerrang
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=kerrang&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=kerrang
 
 ##	Magic
 ##	magic
 #EXTINF:-1 tvg-id="185.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/magic.png" group-title="United Kingdom",Magic
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=magic&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=magic
 
 ##	Kiss
 ##	kiss
 #EXTINF:-1 tvg-id="182.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/kiss.png" group-title="United Kingdom",Kiss
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=kiss&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=kiss
 
 ##	The Box
 ##	the-box
 #EXTINF:-1 tvg-id="279.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/thebox.png" group-title="United Kingdom",The Box
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=the-box&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=the-box
 
 ##	Box Hits
 ##	box-hits
 #EXTINF:-1 tvg-id="267.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/boxhits.png" group-title="United Kingdom",Box Hits
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=box-hits&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=box-hits
 
 ##	Box Upfront
 ##	box-upfront
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/boxupfront.png" group-title="United Kingdom",Box Upfront
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=box-upfront&item_module=resources.lib.channels.uk.boxplus
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/boxplus/get_live_url/?item_id=box-upfront
 
 ##	Quest TV
 ##	questtv
 #EXTINF:-1 tvg-id="1230.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/questtv.png" group-title="United Kingdom",Quest TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=questtv&item_module=resources.lib.channels.uk.questod
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/questod/get_live_url/?item_id=questtv
 
 ##	Quest RED
 ##	questred
 #EXTINF:-1 tvg-id="1014.tvguide.co.uk" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/questred.png" group-title="United Kingdom",Quest RED
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=questred&item_module=resources.lib.channels.uk.questod
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/questod/get_live_url/?item_id=questred
 
 ##	Bristol TV
 ##	bristoltv
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/bristoltv.png" group-title="United Kingdom",Bristol TV
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bristoltv&item_module=resources.lib.channels.uk.bristoltv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/bristoltv/get_live_url/?item_id=bristoltv
 
 ##	Free Sports
 ##	freesports
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/freesports.png" group-title="United Kingdom",Free Sports
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=freesports&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=freesports
 
 ##	STV+1
 ##	stv_plusone
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/stv_plusone.png" group-title="United Kingdom",STV+1
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=stv_plusone&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=stv_plusone
 
 ##	EDGE Sport
 ##	edgesport
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/edgesport.png" group-title="United Kingdom",EDGE Sport
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=edgesport&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=edgesport
 
 ##	The Pet Collective
 ##	thepetcollective
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/thepetcollective.png" group-title="United Kingdom",The Pet Collective
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=thepetcollective&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=thepetcollective
 
 ##	Fail Army
 ##	failarmy
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/failarmy.png" group-title="United Kingdom",Fail Army
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=failarmy&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=failarmy
 
 ##	Qello
 ##	qello
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/qello.png" group-title="United Kingdom",Qello
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qello&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=qello
 
 ##	DUST
 ##	dust
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/uk/dust.png" group-title="United Kingdom",DUST
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dust&item_module=resources.lib.channels.uk.stv
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/uk/stv/get_live_url/?item_id=dust
 
 ##	QVC
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="United Kingdom",QVC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=UK
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=UK
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_us.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_us.m3u
@@ -6,25 +6,25 @@
 ##	CBS News
 ##	cbsnews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/cbsnews.png" group-title="United States of America",CBS News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cbsnews&item_module=resources.lib.channels.us.cbsnews
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/cbsnews/get_live_url/?item_id=cbsnews
 
 ##	TBD
 ##	tbd
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/tbd.png" group-title="United States of America",TBD
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tbd&item_module=resources.lib.channels.us.tbd
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/tbd/get_live_url/?item_id=tbd
 
 ##	ABC News
 ##	abcnews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/abcnews.png" group-title="United States of America",ABC News
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=abcnews&item_module=resources.lib.channels.us.abcnews
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/abcnews/get_live_url/?item_id=abcnews
 
 ##	PBS Kids
 ##	pbskids
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/us/pbskids.png" group-title="United States of America",PBS Kids
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=pbskids&item_module=resources.lib.channels.us.pbskids
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/us/pbskids/get_live_url/?item_id=pbskids
 
 ##	QVC
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="United States of America",QVC
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=US
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=US
 

--- a/plugin.video.catchuptvandmore/resources/m3u/live_tv_wo.m3u
+++ b/plugin.video.catchuptvandmore/resources/m3u/live_tv_wo.m3u
@@ -6,245 +6,245 @@
 ##	Euronews FR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=FR
 
 ##	Euronews EN
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=EN
 
 ##	Euronews AR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=AR
 
 ##	Euronews DE
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=DE
 
 ##	Euronews IT
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews IT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=IT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=IT
 
 ##	Euronews ES
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=ES
 
 ##	Euronews PT
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews PT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=PT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=PT
 
 ##	Euronews RU
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews RU
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=RU
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=RU
 
 ##	Euronews TR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews TR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=TR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=TR
 
 ##	Euronews FA
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews FA
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=FA
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=FA
 
 ##	Euronews GR
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews GR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=GR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=GR
 
 ##	Euronews HU
 ##	euronews
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/euronews.png" group-title="International",Euronews HU
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=euronews&item_module=resources.lib.channels.wo.euronews&language=HU
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/euronews/get_live_url/?item_id=euronews&language=HU
 
 ##	Arte FR
 ##	arte
 #EXTINF:-1 tvg-id="C111.api.telerama.fr" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/arte.png" group-title="International",Arte FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arte&item_module=resources.lib.channels.wo.arte&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/arte/get_live_url/?item_id=arte&language=FR
 
 ##	Arte DE
 ##	arte
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/arte.png" group-title="International",Arte DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arte&item_module=resources.lib.channels.wo.arte&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/arte/get_live_url/?item_id=arte&language=DE
 
 ##	France 24 FR
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=FR
 
 ##	France 24 EN
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=EN
 
 ##	France 24 AR
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=AR
 
 ##	France 24 ES
 ##	france24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/france24.png" group-title="International",France 24 ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=france24&item_module=resources.lib.channels.wo.france24&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/france24/get_live_url/?item_id=france24&language=ES
 
 ##	NHK World Outside Japan
 ##	nhkworld
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/nhkworld.png" group-title="International",NHK World Outside Japan
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nhkworld&item_module=resources.lib.channels.wo.nhkworld&language=Outside+Japan
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/nhkworld/get_live_url/?item_id=nhkworld&language=Outside+Japan
 
 ##	NHK World In Japan
 ##	nhkworld
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/nhkworld.png" group-title="International",NHK World In Japan
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=nhkworld&item_module=resources.lib.channels.wo.nhkworld&language=In+Japan
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/nhkworld/get_live_url/?item_id=nhkworld&language=In+Japan
 
 ##	Tivi 5Monde
 ##	tivi5monde
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/tivi5monde.png" group-title="International",Tivi 5Monde
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tivi5monde&item_module=resources.lib.channels.wo.tivi5monde
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/tivi5monde/get_live_url/?item_id=tivi5monde
 
 ##	BVN
 ##	bvn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/bvn.png" group-title="International",BVN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=bvn&item_module=resources.lib.channels.wo.bvn
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/bvn/get_live_url/?item_id=bvn
 
 ##	ICI Télévision
 ##	icitelevision
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/icitelevision.png" group-title="International",ICI Télévision
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icitelevision&item_module=resources.lib.channels.wo.icitelevision
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/icitelevision/get_live_url/?item_id=icitelevision
 
 ##	Arirang (아리랑)
 ##	arirang
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/arirang.png" group-title="International",Arirang (아리랑)
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=arirang&item_module=resources.lib.channels.wo.arirang
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/arirang/get_live_url/?item_id=arirang
 
 ##	DW EN
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=EN
 
 ##	DW AR
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=AR
 
 ##	DW ES
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=ES
 
 ##	DW DE
 ##	dw
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/dw.png" group-title="International",DW DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=dw&item_module=resources.lib.channels.wo.dw&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/dw/get_live_url/?item_id=dw&language=DE
 
 ##	QVC JP
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC JP
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=JP
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=JP
 
 ##	QVC DE
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC DE
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=DE
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=DE
 
 ##	QVC IT
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC IT
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=IT
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=IT
 
 ##	QVC UK
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC UK
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=UK
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=UK
 
 ##	QVC US
 ##	qvc
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/qvc.png" group-title="International",QVC US
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=qvc&item_module=resources.lib.channels.wo.qvc&language=US
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/qvc/get_live_url/?item_id=qvc&language=US
 
 ##	ICI RDI
 ##	icirdi
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/icirdi.png" group-title="International",ICI RDI
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=icirdi&item_module=resources.lib.channels.wo.icirdi
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/icirdi/get_live_url/?item_id=icirdi
 
 ##	CGTN FR
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=FR
 
 ##	CGTN EN
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=EN
 
 ##	CGTN AR
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=AR
 
 ##	CGTN ES
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=ES
 
 ##	CGTN RU
 ##	cgtn
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtn.png" group-title="International",CGTN RU
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtn&item_module=resources.lib.channels.wo.cgtn&language=RU
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtn&language=RU
 
 ##	CGTN Documentary
 ##	cgtndocumentary
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/cgtndocumentary.png" group-title="International",CGTN Documentary
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=cgtndocumentary&item_module=resources.lib.channels.wo.cgtn
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/cgtn/get_live_url/?item_id=cgtndocumentary
 
 ##	Afrique Media
 ##	afriquemedia
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/afriquemedia.png" group-title="International",Afrique Media
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=afriquemedia&item_module=resources.lib.channels.wo.afriquemedia
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/afriquemedia/get_live_url/?item_id=afriquemedia
 
 ##	TV5Monde France Belgique Suisse
 ##	tv5mondefbs
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/tv5mondefbs.png" group-title="International",TV5Monde France Belgique Suisse
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv5mondefbs&item_module=resources.lib.channels.wo.tv5monde
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5monde/get_live_url/?item_id=tv5mondefbs
 
 ##	TV5Monde Info
 ##	tv5mondeinfo
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/tv5mondeinfo.png" group-title="International",TV5Monde Info
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=tv5mondeinfo&item_module=resources.lib.channels.wo.tv5monde
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/tv5monde/get_live_url/?item_id=tv5mondeinfo
 
 ##	Channel NewsAsia
 ##	channelnewsasia
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/channelnewsasia.png" group-title="International",Channel NewsAsia
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=channelnewsasia&item_module=resources.lib.channels.wo.channelnewsasia
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/channelnewsasia/get_live_url/?item_id=channelnewsasia
 
 ##	RT FR
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT FR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=FR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=FR
 
 ##	RT EN
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT EN
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=EN
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=EN
 
 ##	RT AR
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT AR
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=AR
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=AR
 
 ##	RT ES
 ##	rt
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/rt.png" group-title="International",RT ES
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=rt&item_module=resources.lib.channels.wo.rt&language=ES
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/rt/get_live_url/?item_id=rt&language=ES
 
 ##	Africa 24
 ##	africa24
 #EXTINF:-1 tvg-id="" tvg-logo="resource://resource.images.catchuptvandmore/channels/wo/africa24.png" group-title="International",Africa 24
-plugin://plugin.video.catchuptvandmore/resources/lib/main/live_bridge/?item_id=africa24&item_module=resources.lib.channels.wo.africa24
+plugin://plugin.video.catchuptvandmore/resources/lib/channels/wo/africa24/get_live_url/?item_id=africa24
 

--- a/tools/cq_migration.py
+++ b/tools/cq_migration.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+    Copyright (C) 2016-2020 Team Catch-up TV & More
+    This file is part of Catch-up TV & More.
+    SPDX-License-Identifier: GPL-2.0-or-later
+"""
+
+import sys
+
+filepath = sys.argv[1]
+
+print('Work on %s file' % filepath)
+
+lines = []
+
+with open(filepath, "r") as f:
+    for line in f:
+        lines.append(line)
+
+new_lines = []
+
+modules = []
+for i in range(len(lines)):
+    add_line = True
+    if "'callback':" in lines[i]:
+        lines[i] = lines[i].replace("'callback':", "'resolver':")
+
+    if "'module':" in lines[i]:
+        module = lines[i].split("module': '")[1].split("',")[0]
+        module = module.replace('.', '/')
+        modules.append(module)
+        add_line = False
+
+    if add_line:
+        new_lines.append(lines[i])
+
+cnt = 0
+for i in range(len(new_lines)):
+    add_line = True
+    if "'resolver':" in new_lines[i]:
+        new_lines[i] = new_lines[i].replace("live_bridge", '/' + modules[cnt] + ':get_live_url')
+        cnt = cnt + 1
+
+with open(filepath, 'w') as f:
+    for line in new_lines:
+        f.write(line)

--- a/tools/generate_m3u_files.py
+++ b/tools/generate_m3u_files.py
@@ -51,7 +51,7 @@ LIVE_TV_M3U_COUTRY_FILEPATH = "../plugin.video.catchuptvandmore/resources/m3u/li
 EN_STRINGS_PO_FILEPATH = "../plugin.video.catchuptvandmore/resources/language/resource.language.en_gb/strings.po"
 
 
-PLUGIN_LIVE_BRIDGE_PATH = "plugin://plugin.video.catchuptvandmore/resources/lib/main/"
+PLUGIN_PATH = "plugin://plugin.video.catchuptvandmore"
 
 M3U_ENTRY = '#EXTINF:-1 tvg-id="%s" tvg-logo="%s" group-title="%s",%s\n%s'
 # arg0: tgv_id
@@ -170,7 +170,7 @@ def generate_m3u_files():
                 continue
 
             # If this channel is a folder (e.g. multi live) --> ignore this channel
-            if channel_infos.get('callback') != 'live_bridge':
+            if 'resolver' not in channel_infos:
                 continue
 
             channel_label = get_label(channel_id, channel_infos)
@@ -186,12 +186,11 @@ def generate_m3u_files():
             for language in languages:
 
                 channel_m3u = {
-                    'callback': channel_infos['callback'],
+                    'resolver': channel_infos['resolver'].replace(':', '/'),
                     'logo': get_item_media_path(channel_infos["thumb"]),
                     'label': channel_label,
                     'params': {
-                        'item_id': channel_id,
-                        'item_module': channel_infos['module']
+                        'item_id': channel_id
                     },
                     'xmltv_id': channel_infos.get('xmltv_id', ''),
                     'group': country_label if 'm3u_group' not in channel_infos else country_label + ' ' + channel_infos['m3u_group'],
@@ -276,10 +275,10 @@ def generate_m3u_files():
             channel_group = channel_dict['group']
             channel_group_all = channel_dict['group_all']
             channel_xmltv_id = channel_dict['xmltv_id']
-            channel_callback = channel_dict['callback']
+            channel_resolver = channel_dict['resolver']
 
             query = urllib.parse.urlencode(channel_params)
-            channel_url = PLUGIN_LIVE_BRIDGE_PATH + channel_callback + '/?' + query
+            channel_url = PLUGIN_PATH + channel_resolver + '/?' + query
 
             channel_m3u_entry_country = M3U_ENTRY % (
                 channel_xmltv_id, channel_logo, channel_group,


### PR DESCRIPTION
CodeQuick 0.9.13 est en cours de review pour être dispo sur le repo officiel de Kodi.

Grâce à cette version on va pouvoir se débarrasser de toutes les fonctions "bridge" qui sont dans le `main.py` sans perdre en vitesse d'exécution.

Dans les fichiers skeleton on pourra directement spécifier quelle fonction de quel module doit être appelé ; par conséquent on pourra même avoir plusieurs points d'entrée pour un même module (par exemple si M6 et W9 doivent entrer dans le fichier `6play.py` par une fonction différente et bien ça sera possible).

En plus, je pense que la compréhension du plugin sera plus simple pour d'éventuels nouveaux contributeurs.

cc @wwark 