### PR TITLE
Add setting for custom ffmpeg location

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -377,6 +377,10 @@ msgctxt "#30203"
 msgid "Automatically rename the video (download directory required)"
 msgstr ""
 
+msgctxt "#30204"
+msgid "Ffmpeg executable directory"
+msgstr ""
+
 
 # Accounts (from 30240 to 30269)
 

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -377,6 +377,10 @@ msgctxt "#30203"
 msgid "Automatically rename the video (download directory required)"
 msgstr "Renommer automatiquement la vidéo (répertoire de téléchargement requis)"
 
+msgctxt "#30204"
+msgid "Ffmpeg executable directory"
+msgstr "Répertoire de l'exécutable ffmpeg"
+
 
 # Accounts (from 30240 to 30259)
 

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -376,6 +376,9 @@ msgctxt "#30203"
 msgid "Automatically rename the video (download directory required)"
 msgstr ""
 
+msgctxt "#30204"
+msgid "Ffmpeg executable directory"
+msgstr "ספריית הפעלה של Ffmpeg"
 
 # Accounts (from 30240 to 30259)
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -376,6 +376,10 @@ msgctxt "#30203"
 msgid "Automatically rename the video (download directory required)"
 msgstr "Hernoem de video automatisch (download map vereist)"
 
+msgctxt "#30204"
+msgid "Ffmpeg executable directory"
+msgstr "Ffmpeg uitvoerbare map"
+
 
 # Accounts (from 30240 to 30259)
 

--- a/resources/lib/download.py
+++ b/resources/lib/download.py
@@ -27,6 +27,10 @@ def download_video(video_url):
     YDStreamUtils = __import__('YDStreamUtils')
     YDStreamExtractor = __import__('YDStreamExtractor')
 
+    ffmpeg_folder = Script.setting.get_string('ffmpeg_folder')
+    if ffmpeg_folder:
+        YDStreamExtractor.overrideParam("ffmpeg_location", ffmpeg_folder)
+
     vid = YDStreamExtractor.getVideoInfo(
         video_url,
         quality=get_quality_YTDL(download_mode=True),

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -91,6 +91,7 @@
         <setting label="30201" type="labelenum" id="dl_quality" visible="true" values="SD|720p|1080p|Highest available" default="Highest available"/>
         <setting label="30202" type="bool" id="dl_background" default="false" visible="true"/>
         <setting label="30203" type="bool" id="dl_item_filename" default="false" visible="true"/>
+        <setting label="30204" type="folder" id="ffmpeg_folder" source=""/>
     </category>
     <!-- Downloads -->
 


### PR DESCRIPTION
Bonjour,

Je vous propose un PR qui ajoute à CUTV&More une option permettant de définir un chemin personalisé vers le binaire ffmpeg.
J'ai toutefois queqlues questions :
- j'ai provisoirement ajouté l'option dans la catégorie "Téléchargement", mais peut-être faudrait-il l'ajouter dans "Avancé" ? ;
- faut-il être plus précis dans la description du paramètre ? ;
- mon environnement de test est assez limité (Linux + Kodi), serait-il possible que vous les complétiez ?

Ce PR n'implique aucune modification à l'extension YoutubeDL de ruuk dans sa dernière version officielle.
Merci d'avance.
