### PR TITLE
Arte TV : nombre d'épisodes limités à 8 (fix #380)

### DIFF
--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/arte.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/arte.py
@@ -108,7 +108,6 @@ def list_sub_categories(plugin, item_id, category_url, **kwargs):
     - Les feux de l'amour
     - ...
     """
-    # import web_pdb; web_pdb.set_trace()
 
     resp = urlquick.get(category_url)
     json_value = re.compile(r'_INITIAL_STATE__ \= (.*?)\}\;').findall(

--- a/plugin.video.catchuptvandmore/resources/lib/channels/wo/arte.py
+++ b/plugin.video.catchuptvandmore/resources/lib/channels/wo/arte.py
@@ -108,6 +108,8 @@ def list_sub_categories(plugin, item_id, category_url, **kwargs):
     - Les feux de l'amour
     - ...
     """
+    # import web_pdb; web_pdb.set_trace()
+
     resp = urlquick.get(category_url)
     json_value = re.compile(r'_INITIAL_STATE__ \= (.*?)\}\;').findall(
         resp.text)[0]
@@ -152,20 +154,23 @@ def list_sub_categories(plugin, item_id, category_url, **kwargs):
                 'ARTE_CONCERT' in sub_category_datas['code']['name'] or \
                 'highlights_category' in sub_category_datas['code']['name'] or \
                 '-' in sub_category_datas['code']['name'] or \
+                'collection_videos' in sub_category_datas['code']['name'] or \
                 'collection_subcollection' in sub_category_datas['code']['name']:
-            sub_category_title = sub_category_datas['title']
-            sub_category_code_name = sub_category_datas['code']['name']
-            sub_category_url = category_url
+            if sub_category_datas['data']:
+                sub_category_title = sub_category_datas['title']
+                sub_category_code_name = sub_category_datas['code']['name']
+                sub_category_url = category_url
 
-            item = Listitem()
-            item.label = sub_category_title
+                item = Listitem()
+                item.label = sub_category_title
 
-            item.set_callback(list_programs,
-                              item_id=item_id,
-                              sub_category_code_name=sub_category_code_name,
-                              sub_category_url=sub_category_url)
-            item_post_treatment(item)
-            yield item
+                item.set_callback(list_programs,
+                                  item_id=item_id,
+                                  sub_category_title=sub_category_title,
+                                  sub_category_code_name=sub_category_code_name,
+                                  sub_category_url=sub_category_url)
+                item_post_treatment(item)
+                yield item
 
         # else:
         #     # Add Notification (Category Not known)
@@ -173,107 +178,212 @@ def list_sub_categories(plugin, item_id, category_url, **kwargs):
 
 
 @Route.register
-def list_programs(plugin, item_id, sub_category_code_name, sub_category_url,
+def list_programs(plugin, item_id, sub_category_title, sub_category_code_name, sub_category_url,
                   **kwargs):
     """
     Build programs listing
     - Les feux de l'amour
     - ...
     """
-    resp = urlquick.get(sub_category_url)
-    json_value = re.compile(r'_INITIAL_STATE__ \= (.*?)\}\;').findall(
-        resp.text)[0]
-    json_parser = json.loads(json_value + '}')
 
-    value_code = json_parser['pages']['currentCode']
-    for sub_category_datas in json_parser['pages']['list'][value_code][
-            'zones']:
-        if sub_category_datas['code']['name'] == sub_category_code_name:
-            for program_datas in sub_category_datas['data']:
-                if program_datas["kind"]["isCollection"]:
-                    program_title = program_datas['title']
-                    program_url = program_datas['url']
-                    program_image = ''
-                    if program_datas['images']['landscape'] is not None:
-                        if 'resolutions' in program_datas['images']['landscape']:
-                            for image_datas in program_datas['images']['landscape'][
-                                    'resolutions']:
-                                program_image = image_datas['url']
-                    elif program_datas['images']['square'] is not None:
-                        if 'resolutions' in program_datas['images']['square']:
-                            for image_datas in program_datas['images']['square'][
-                                    'resolutions']:
-                                program_image = image_datas['url']
+    if '/api/' in sub_category_url:
+        resp = urlquick.get(sub_category_url.replace('https://api-internal.arte.tv', 'https://www.arte.tv/guide'))
+        json_parser = json.loads(resp.text)
+        # for video_datas in json_parser['data']:
+        for program_datas in json_parser['data']:
+            if program_datas["kind"]["isCollection"]:
+                program_title = program_datas['title']
+                program_url = program_datas['url']
+                program_image = ''
+                if program_datas['images']['landscape'] is not None:
+                    if 'resolutions' in program_datas['images']['landscape']:
+                        for image_datas in program_datas['images']['landscape'][
+                                'resolutions']:
+                            program_image = image_datas['url']
+                elif program_datas['images']['square'] is not None:
+                    if 'resolutions' in program_datas['images']['square']:
+                        for image_datas in program_datas['images']['square'][
+                                'resolutions']:
+                            program_image = image_datas['url']
 
-                    item = Listitem()
-                    item.label = program_title
-                    item.art['thumb'] = item.art['landscape'] = program_image
-                    item.set_callback(
-                        list_sub_categories,
-                        item_id=item_id,
-                        category_url=program_url)
-                    item_post_treatment(item)
-                    yield item
-                elif program_datas['programId'] is not None and 'RC-' in program_datas['programId']:
-                    program_title = program_datas['title']
-                    program_id = program_datas['programId']
-                    program_image = ''
-                    if program_datas['images']['landscape'] is not None:
-                        if 'resolutions' in program_datas['images']['landscape']:
-                            for image_datas in program_datas['images']['landscape'][
-                                    'resolutions']:
-                                program_image = image_datas['url']
-                    elif program_datas['images']['square'] is not None:
-                        if 'resolutions' in program_datas['images']['square']:
-                            for image_datas in program_datas['images']['square'][
-                                    'resolutions']:
-                                program_image = image_datas['url']
+                item = Listitem()
+                item.label = program_title
+                item.art['thumb'] = item.art['landscape'] = program_image
+                item.set_callback(
+                    list_sub_categories,
+                    item_id=item_id,
+                    category_url=program_url)
+                item_post_treatment(item)
+                yield item
+            elif program_datas['programId'] is not None and 'RC-' in program_datas['programId']:
+                program_title = program_datas['title']
+                program_id = program_datas['programId']
+                program_image = ''
+                if program_datas['images']['landscape'] is not None:
+                    if 'resolutions' in program_datas['images']['landscape']:
+                        for image_datas in program_datas['images']['landscape'][
+                                'resolutions']:
+                            program_image = image_datas['url']
+                elif program_datas['images']['square'] is not None:
+                    if 'resolutions' in program_datas['images']['square']:
+                        for image_datas in program_datas['images']['square'][
+                                'resolutions']:
+                            program_image = image_datas['url']
 
-                    item = Listitem()
-                    item.label = program_title
-                    item.art['thumb'] = item.art['landscape'] = program_image
-                    item.set_callback(
-                        list_videos_program,
-                        item_id=item_id,
-                        sub_category_code_name=sub_category_code_name,
-                        program_id=program_id)
-                    item_post_treatment(item)
-                    yield item
+                item = Listitem()
+                item.label = program_title
+                item.art['thumb'] = item.art['landscape'] = program_image
+                item.set_callback(
+                    list_videos_program,
+                    item_id=item_id,
+                    sub_category_code_name=sub_category_code_name,
+                    program_id=program_id)
+                item_post_treatment(item)
+                yield item
+            else:
+                if program_datas['subtitle'] is not None:
+                    video_title = program_datas['title'] + ' - ' + program_datas[
+                        'subtitle']
                 else:
-                    if program_datas['subtitle'] is not None:
-                        video_title = program_datas['title'] + ' - ' + program_datas[
-                            'subtitle']
+                    video_title = program_datas['title']
+                video_id = program_datas['programId']
+                video_image = ''
+                if program_datas['images']['landscape'] is not None:
+                    if 'resolutions' in program_datas['images']['landscape']:
+                        for video_image_datas in program_datas['images'][
+                                'landscape']['resolutions']:
+                            video_image = video_image_datas['url']
+                elif program_datas['images']['square'] is not None:
+                    if 'resolutions' in program_datas['images']['square']:
+                        for image_datas in program_datas['images']['square'][
+                                'resolutions']:
+                            program_image = image_datas['url']
+                video_duration = program_datas["duration"]
+                video_plot = program_datas.get("shortDescription", '')
+
+                item = Listitem()
+                item.label = video_title
+                item.art['thumb'] = item.art['landscape'] = video_image
+                item.info['duration'] = video_duration
+                item.info['plot'] = video_plot
+
+                item.set_callback(get_video_url,
+                                  item_id=item_id,
+                                  video_id=video_id)
+                item_post_treatment(item,
+                                    is_playable=True,
+                                    is_downloadable=True)
+                yield item
+
+        if json_parser['nextPage'] is not None:
+            yield Listitem.next_page(
+                item_id=item_id,
+                sub_category_title=sub_category_title,
+                sub_category_code_name=sub_category_code_name,
+                sub_category_url=json_parser['nextPage'])
+    else:
+        resp = urlquick.get(sub_category_url)
+        json_value = re.compile(r'_INITIAL_STATE__ \= (.*?)\}\;').findall(
+            resp.text)[0]
+        json_parser = json.loads(json_value + '}')
+
+        value_code = json_parser['pages']['currentCode']
+        for sub_category_datas in json_parser['pages']['list'][value_code][
+                'zones']:
+            if (sub_category_datas['code']['name'] == sub_category_code_name and
+                sub_category_title == sub_category_datas['title']):
+
+                for program_datas in sub_category_datas['data']:
+                    if program_datas["kind"]["isCollection"]:
+                        program_title = program_datas['title']
+                        program_url = program_datas['url']
+                        program_image = ''
+                        if program_datas['images']['landscape'] is not None:
+                            if 'resolutions' in program_datas['images']['landscape']:
+                                for image_datas in program_datas['images']['landscape'][
+                                        'resolutions']:
+                                    program_image = image_datas['url']
+                        elif program_datas['images']['square'] is not None:
+                            if 'resolutions' in program_datas['images']['square']:
+                                for image_datas in program_datas['images']['square'][
+                                        'resolutions']:
+                                    program_image = image_datas['url']
+
+                        item = Listitem()
+                        item.label = program_title
+                        item.art['thumb'] = item.art['landscape'] = program_image
+                        item.set_callback(
+                            list_sub_categories,
+                            item_id=item_id,
+                            category_url=program_url)
+                        item_post_treatment(item)
+                        yield item
+                    elif program_datas['programId'] is not None and 'RC-' in program_datas['programId']:
+                        program_title = program_datas['title']
+                        program_id = program_datas['programId']
+                        program_image = ''
+                        if program_datas['images']['landscape'] is not None:
+                            if 'resolutions' in program_datas['images']['landscape']:
+                                for image_datas in program_datas['images']['landscape'][
+                                        'resolutions']:
+                                    program_image = image_datas['url']
+                        elif program_datas['images']['square'] is not None:
+                            if 'resolutions' in program_datas['images']['square']:
+                                for image_datas in program_datas['images']['square'][
+                                        'resolutions']:
+                                    program_image = image_datas['url']
+
+                        item = Listitem()
+                        item.label = program_title
+                        item.art['thumb'] = item.art['landscape'] = program_image
+                        item.set_callback(
+                            list_videos_program,
+                            item_id=item_id,
+                            sub_category_code_name=sub_category_code_name,
+                            program_id=program_id)
+                        item_post_treatment(item)
+                        yield item
                     else:
-                        video_title = program_datas['title']
-                    video_id = program_datas['programId']
-                    video_image = ''
-                    if program_datas['images']['landscape'] is not None:
-                        if 'resolutions' in program_datas['images']['landscape']:
-                            for video_image_datas in program_datas['images'][
-                                    'landscape']['resolutions']:
-                                video_image = video_image_datas['url']
-                    elif program_datas['images']['square'] is not None:
-                        if 'resolutions' in program_datas['images']['square']:
-                            for image_datas in program_datas['images']['square'][
-                                    'resolutions']:
-                                program_image = image_datas['url']
-                    video_duration = program_datas["duration"]
-                    video_plot = program_datas.get("shortDescription", '')
+                        if program_datas['subtitle'] is not None:
+                            video_title = program_datas['title'] + ' - ' + program_datas[
+                                'subtitle']
+                        else:
+                            video_title = program_datas['title']
+                        video_id = program_datas['programId']
+                        video_image = ''
+                        if program_datas['images']['landscape'] is not None:
+                            if 'resolutions' in program_datas['images']['landscape']:
+                                for video_image_datas in program_datas['images'][
+                                        'landscape']['resolutions']:
+                                    video_image = video_image_datas['url']
+                        elif program_datas['images']['square'] is not None:
+                            if 'resolutions' in program_datas['images']['square']:
+                                for image_datas in program_datas['images']['square'][
+                                        'resolutions']:
+                                    program_image = image_datas['url']
+                        video_duration = program_datas["duration"]
+                        video_plot = program_datas.get("shortDescription", '')
 
-                    item = Listitem()
-                    item.label = video_title
-                    item.art['thumb'] = item.art['landscape'] = video_image
-                    item.info['duration'] = video_duration
-                    item.info['plot'] = video_plot
+                        item = Listitem()
+                        item.label = video_title
+                        item.art['thumb'] = item.art['landscape'] = video_image
+                        item.info['duration'] = video_duration
+                        item.info['plot'] = video_plot
 
-                    item.set_callback(get_video_url,
-                                      item_id=item_id,
-                                      video_id=video_id)
-                    item_post_treatment(item,
-                                        is_playable=True,
-                                        is_downloadable=True)
-                    yield item
+                        item.set_callback(get_video_url,
+                                          item_id=item_id,
+                                          video_id=video_id)
+                        item_post_treatment(item,
+                                            is_playable=True,
+                                            is_downloadable=True)
+                        yield item
 
+                if sub_category_datas['nextPage'] is not None:
+                    yield Listitem.next_page(
+                        item_id=item_id,
+                        sub_category_title=sub_category_title,
+                        sub_category_code_name=sub_category_code_name,
+                        sub_category_url=sub_category_datas['nextPage'])
 
 @Route.register
 def list_programs_concert(plugin, item_id, sub_category_code_name, sub_category_url,


### PR DESCRIPTION
Corrige trois problèmes dans arte.tv :
- nombre d'épisodes limités à 8
- épisodes mélangés entre saisons/émissions
- certaines catégories (Sciences, Histoire...) renvoient
l'erreur "No item found"