### PR TITLE
Disable playcount for live streams

### DIFF
--- a/plugin.video.catchuptvandmore/resources/lib/main.py
+++ b/plugin.video.catchuptvandmore/resources/lib/main.py
@@ -201,6 +201,10 @@ def tv_guide_menu(plugin, item_id, **kwargs):
             # Art
             if 'icon' in guide_infos:
                 item.art["thumb"] = guide_infos['icon']
+
+        # Playcount is useless for live streams
+        item.info['playcount'] = 0
+
         yield item
 
 


### PR DESCRIPTION
Since live streams typically broadcast different content, having a
playcount is useless and even confusing. This disables playcount (and
watched indication) for live streams.