### PR TITLE
Add scripts to manage translations and update NL translation.

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -4,16 +4,9 @@
 # Addon Provider: SylvainCecchetto
 msgid ""
 msgstr ""
-"Project-Id-Version: Kodi Addons\n"
-"Report-Msgid-Bugs-To: alanwww1@kodi.org\n"
-"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: SylvainCecchetto\n"
-"Language-Team: \n"
-"MIME-Version: 1.0\n"
+"Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -4,21 +4,12 @@
 # Addon Provider: SylvainCecchetto
 msgid ""
 msgstr ""
-"Project-Id-Version: Kodi Addons\n"
-"Report-Msgid-Bugs-To: alanwww1@kodi.org\n"
-"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: SylvainCecchetto\n"
-"Language-Team: \n"
-"MIME-Version: 1.0\n"
+"Language: fr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-
 # Settings tabs/categories (from 30000 to 30019)
-
 msgctxt "#30000"
 msgid ""
 msgstr ""
@@ -59,9 +50,7 @@ msgctxt "#30009"
 msgid "General"
 msgstr "Général"
 
-
 # Settings line separators (from 30010 to 30029)
-
 msgctxt "#30010"
 msgid "Hide main menu categories"
 msgstr "Masquer des catégories du menu principal"
@@ -106,9 +95,7 @@ msgctxt "#30020"
 msgid "Unmask replay TV channels"
 msgstr "Démasquer les chaînes des replay TV"
 
-
 # Main menu (from 30030 to 30049)
-
 msgctxt "#30030"
 msgid "Live TV"
 msgstr "TV en direct"
@@ -125,9 +112,7 @@ msgctxt "#30033"
 msgid "Favourites"
 msgstr "Favoris"
 
-
 # Countries (from 30050 to 30079)
-
 msgctxt "#30050"
 msgid "France"
 msgstr "France"
@@ -196,9 +181,7 @@ msgctxt "#30066"
 msgid "Ethiopia"
 msgstr "Ethiopie"
 
-
 # Channels (from 30080 to 30129)
-
 msgctxt "#30080"
 msgid "French channels"
 msgstr "Chaînes françaises"
@@ -264,16 +247,11 @@ msgid "Slovenian channels"
 msgstr "Chaînes slovène"
 
 msgctxt "#30096"
-msgid "Chaînes ethiopiennes"
-msgstr ""
-
+msgid "Ethiopian channels"
+msgstr "Chaînes ethiopiennes"
 
 # Websites (from 30130 to 30149)
-
-
-
 # Quality and content (from 30150 to 30199)
-
 msgctxt "#30150"
 msgid "Video quality"
 msgstr "Qualité vidéo"
@@ -358,9 +336,7 @@ msgctxt "#30170"
 msgid "CBC: Choose region"
 msgstr "CBC : Choix de la région"
 
-
 # Download (from 30200 to 30239)
-
 msgctxt "#30200"
 msgid "Download directory"
 msgstr "Répertoire de téléchargement"
@@ -377,9 +353,7 @@ msgctxt "#30203"
 msgid "Automatically rename the video (download directory required)"
 msgstr "Renommer automatiquement la vidéo (répertoire de téléchargement requis)"
 
-
-# Accounts (from 30240 to 30259)
-
+# Accounts (from 30240 to 30269)
 msgctxt "#30240"
 msgid "NRJ Login"
 msgstr "Login NRJ"
@@ -428,9 +402,7 @@ msgctxt "#30251"
 msgid "UKTVPlay Password"
 msgstr "Mot de passe UKTVPlay"
 
-
 # TV integration (from 30270 to 30289)
-
 msgctxt "#30270"
 msgid "TV integration"
 msgstr "Intégration TV"
@@ -463,15 +435,9 @@ msgctxt "#30277"
 msgid "Select channels to enable in Kodi Live TV"
 msgstr "Sélectionner les chaînes à activer dans la section Live TV de Kodi"
 
-
-
 # Reserved space for other tab/category in settins (from 30290 to 30339)
-
-
-
 # delete_for_submission_start
 # OpenVPN (from 30340 to 30369)
-
 msgctxt "#30340"
 msgid "Enable VPN feature"
 msgstr "Activer la fonctionnalité VPN"
@@ -559,11 +525,9 @@ msgstr "Choisissez la configuration OpenVPN à supprimer"
 msgctxt "#30361"
 msgid "Connect/Disconnect VPN"
 msgstr "Connecter/Déconnecter VPN"
+
 # delete_for_submission_end
-
-
 # Advanced settings (from 30370 to 30399)
-
 msgctxt "#30370"
 msgid "Clear cache"
 msgstr "Vider le cache"
@@ -584,9 +548,7 @@ msgctxt "#30374"
 msgid "Favourites deleted"
 msgstr "Favoris supprimés"
 
-
 # Settings of 'General' category (from 30400 to 30429)
-
 msgctxt "#30400"
 msgid "Restore default order of all menus"
 msgstr "Restaurer l'ordre par défaut de tous les menus"
@@ -623,20 +585,13 @@ msgctxt "#30408"
 msgid "All hidden items have been unmasked"
 msgstr "Tous les éléments masqués ont été démasqué"
 
-
 # Advanced settings (from 30430 to 30449)
-
 msgctxt "#30430"
 msgid "Automatically start Catch-up TV & More when Kodi starts"
 msgstr "Lancer automatiquement Catch-up TV & More au démarrage de Kodi"
 
-
 # Reserved space for other tab/category in settins (from 30450 to 30499)
-
-
-
 # Context menu (from 30500 to 30599)
-
 msgctxt "#30500"
 msgid "Move down"
 msgstr "Descendre"
@@ -661,9 +616,7 @@ msgctxt "#30505"
 msgid "List Videos (type=episode)"
 msgstr "Liste des Videos (type=episode)"
 
-
 # Dialog boxes (from 30600 to 30699)
-
 msgctxt "#30600"
 msgid "Information"
 msgstr "Information"
@@ -692,9 +645,7 @@ msgctxt "#30606"
 msgid "Do you want to see this information next time?"
 msgstr "Voulez-vous voir cette information la prochaine fois ?"
 
-
 # Others (from 30700 to 30799)
-
 msgctxt "#30700"
 msgid "More videos..."
 msgstr "Plus de vidéos..."
@@ -803,9 +754,7 @@ msgctxt "#30726"
 msgid "Races"
 msgstr "Courses"
 
-
 # Favourites (from 30800 to 30859)
-
 msgctxt "#30800"
 msgid "Add to add-on favourites"
 msgstr "Ajouter aux favoris du plugin"
@@ -838,9 +787,7 @@ msgctxt "#30807"
 msgid "This favourite raises an error, would you like to delete it?"
 msgstr "Ce favori déclenche une erreur, souhaitez vous le supprimer ?"
 
-
 # Log uploader (from 30860 to 30889)
-
 msgctxt "#30860"
 msgid "This selection triggered an unexpected error, would you like to share your error log so that we can try to resolve this issue?"
 msgstr "Cette sélection a déclenché une erreur inattendue, souhaitez-vous nous partager votre journal d'erreurs afin que nous puissions essayer de résoudre ce problème ?"
@@ -853,9 +800,7 @@ msgctxt "#30862"
 msgid "Sorry, sharing your error log failed"
 msgstr "Désolé, le partage de votre journal d'erreurs a échoué"
 
-
 # HTTP error (from 30890 to 30919)
-
 msgctxt "#30890"
 msgid "HTTP Error code"
 msgstr "Erreur HTTP code"

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -4,21 +4,12 @@
 # Addon Provider: SylvainCecchetto
 msgid ""
 msgstr ""
-"Project-Id-Version: Kodi Addons\n"
-"Report-Msgid-Bugs-To: alanwww1@kodi.org\n"
-"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: SylvainCecchetto\n"
-"Language-Team: \n"
-"MIME-Version: 1.0\n"
+"Language: he\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-
 # Settings tabs/categories (from 30000 to 30019)
-
 msgctxt "#30000"
 msgid ""
 msgstr ""
@@ -59,9 +50,7 @@ msgctxt "#30009"
 msgid "General"
 msgstr ""
 
-
 # Settings line separators (from 30010 to 30029)
-
 msgctxt "#30010"
 msgid "Hide main menu categories"
 msgstr "הסתר קטגוריות בתפריט הראשי"
@@ -106,9 +95,7 @@ msgctxt "#30020"
 msgid "Unmask replay TV channels"
 msgstr ""
 
-
 # Main menu (from 30030 to 30049)
-
 msgctxt "#30030"
 msgid "Live TV"
 msgstr "טלוויזיה חיה"
@@ -125,9 +112,7 @@ msgctxt "#30033"
 msgid "Favourites"
 msgstr ""
 
-
 # Countries (from 30050 to 30079)
-
 msgctxt "#30050"
 msgid "France"
 msgstr ""
@@ -196,9 +181,7 @@ msgctxt "#30066"
 msgid "Ethiopia"
 msgstr ""
 
-
 # Channels (from 30080 to 30129)
-
 msgctxt "#30080"
 msgid "French channels"
 msgstr "ערוצים צרפתיים"
@@ -268,11 +251,7 @@ msgid "Ethiopian channels"
 msgstr ""
 
 # Websites (from 30130 to 30149)
-
-
-
 # Quality and content (from 30150 to 30199)
-
 msgctxt "#30150"
 msgid "Video quality"
 msgstr "איכות וידאו מיו-טיוב"
@@ -357,9 +336,7 @@ msgctxt "#30170"
 msgid "CBC: Choose region"
 msgstr ""
 
-
 # Download (from 30200 to 30239)
-
 msgctxt "#30200"
 msgid "Download directory"
 msgstr "תיקיה להורדה"
@@ -376,9 +353,7 @@ msgctxt "#30203"
 msgid "Automatically rename the video (download directory required)"
 msgstr ""
 
-
-# Accounts (from 30240 to 30259)
-
+# Accounts (from 30240 to 30269)
 msgctxt "#30240"
 msgid "NRJ Login"
 msgstr ""
@@ -427,10 +402,7 @@ msgctxt "#30251"
 msgid "UKTVPlay Password"
 msgstr ""
 
-
-
 # TV integration (from 30270 to 30289)
-
 msgctxt "#30270"
 msgid "TV integration"
 msgstr ""
@@ -463,15 +435,9 @@ msgctxt "#30277"
 msgid "Select channels to enable in Kodi Live TV"
 msgstr ""
 
-
-
 # Reserved space for other tab/category in settins (from 30290 to 30339)
-
-
-
 # delete_for_submission_start
 # OpenVPN (from 30340 to 30369)
-
 msgctxt "#30340"
 msgid "Enable VPN feature"
 msgstr ""
@@ -559,11 +525,9 @@ msgstr ""
 msgctxt "#30361"
 msgid "Connect/Disconnect VPN"
 msgstr ""
+
 # delete_for_submission_end
-
-
 # Advanced settings (from 30370 to 30399)
-
 msgctxt "#30370"
 msgid "Clear cache"
 msgstr ""
@@ -584,9 +548,7 @@ msgctxt "#30374"
 msgid "Favourites deleted"
 msgstr ""
 
-
 # Settings of 'General' category (from 30400 to 30429)
-
 msgctxt "#30400"
 msgid "Restore default order of all menus"
 msgstr ""
@@ -623,20 +585,13 @@ msgctxt "#30408"
 msgid "All hidden items have been unmasked"
 msgstr ""
 
-
 # Advanced settings (from 30430 to 30449)
-
 msgctxt "#30430"
 msgid "Automatically start Catch-up TV & More when Kodi starts"
 msgstr ""
 
-
 # Reserved space for other tab/category in settins (from 30450 to 30499)
-
-
-
 # Context menu (from 30500 to 30599)
-
 msgctxt "#30500"
 msgid "Move down"
 msgstr "רד למטה"
@@ -661,9 +616,7 @@ msgctxt "#30505"
 msgid "List Videos (type=episode)"
 msgstr ""
 
-
 # Dialog boxes (from 30600 to 30699)
-
 msgctxt "#30600"
 msgid "Information"
 msgstr "מידע"
@@ -692,9 +645,7 @@ msgctxt "#30606"
 msgid "Do you want to see this information next time?"
 msgstr ""
 
-
 # Others (from 30700 to 30799)
-
 msgctxt "#30700"
 msgid "More videos..."
 msgstr "קטעי וידאו נוספים..."
@@ -803,9 +754,7 @@ msgctxt "#30726"
 msgid "Races"
 msgstr ""
 
-
 # Favourites (from 30800 to 30859)
-
 msgctxt "#30800"
 msgid "Add to add-on favourites"
 msgstr ""
@@ -838,9 +787,7 @@ msgctxt "#30807"
 msgid "This favourite raises an error, would you like to delete it?"
 msgstr ""
 
-
 # Log uploader (from 30860 to 30889)
-
 msgctxt "#30860"
 msgid "This selection triggered an unexpected error, would you like to share your error log so that we can try to resolve this issue?"
 msgstr ""
@@ -853,9 +800,7 @@ msgctxt "#30862"
 msgid "Sorry, sharing your error log failed"
 msgstr ""
 
-
 # HTTP error (from 30890 to 30919)
-
 msgctxt "#30890"
 msgid "HTTP Error code"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -4,21 +4,12 @@
 # Addon Provider: SylvainCecchetto
 msgid ""
 msgstr ""
-"Project-Id-Version: Kodi Addons\n"
-"Report-Msgid-Bugs-To: alanwww1@kodi.org\n"
-"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: AgeBosma\n"
-"Language-Team: \n"
-"MIME-Version: 1.0\n"
+"Language: nl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-
 # Settings tabs/categories (from 30000 to 30019)
-
 msgctxt "#30000"
 msgid ""
 msgstr ""
@@ -57,11 +48,9 @@ msgstr ""
 
 msgctxt "#30009"
 msgid "General"
-msgstr ""
-
+msgstr "Algemeen"
 
 # Settings line separators (from 30010 to 30029)
-
 msgctxt "#30010"
 msgid "Hide main menu categories"
 msgstr "Verberg hoofdmenu categorieën"
@@ -92,7 +81,7 @@ msgstr "Verberg replay tv landen"
 
 msgctxt "#30017"
 msgid "Default values"
-msgstr ""
+msgstr "Standaardwaarden"
 
 msgctxt "#30018"
 msgid "Unmask main menus items"
@@ -106,9 +95,7 @@ msgctxt "#30020"
 msgid "Unmask replay TV channels"
 msgstr ""
 
-
 # Main menu (from 30030 to 30049)
-
 msgctxt "#30030"
 msgid "Live TV"
 msgstr "Live tv"
@@ -125,9 +112,7 @@ msgctxt "#30033"
 msgid "Favourites"
 msgstr "Favorieten"
 
-
 # Countries (from 30050 to 30079)
-
 msgctxt "#30050"
 msgid "France"
 msgstr "Frankrijk"
@@ -186,19 +171,17 @@ msgstr "China"
 
 msgctxt "#30064"
 msgid "Cameroon"
-msgstr ""
+msgstr "Kameroen"
 
 msgctxt "#30065"
 msgid "Slovenia"
-msgstr ""
+msgstr "Slovenië"
 
 msgctxt "#30066"
 msgid "Ethiopia"
-msgstr ""
-
+msgstr "Ethiopië"
 
 # Channels (from 30080 to 30129)
-
 msgctxt "#30080"
 msgid "French channels"
 msgstr "Franse kanalen"
@@ -257,22 +240,18 @@ msgstr "Chinese kanalen"
 
 msgctxt "#30094"
 msgid "Cameroon channels"
-msgstr "Cameroon kanalen"
+msgstr "Kameroense kanalen"
 
 msgctxt "#30095"
 msgid "Slovenian channels"
-msgstr ""
+msgstr "Sloveense kanalen"
 
 msgctxt "#30096"
 msgid "Ethiopian channels"
-msgstr ""
+msgstr "Ethiopische kanalen"
 
 # Websites (from 30130 to 30149)
-
-
-
 # Quality and content (from 30150 to 30199)
-
 msgctxt "#30150"
 msgid "Video quality"
 msgstr "Video kwaliteit"
@@ -357,9 +336,7 @@ msgctxt "#30170"
 msgid "CBC: Choose region"
 msgstr "CBC : Kies regio"
 
-
 # Download (from 30200 to 30239)
-
 msgctxt "#30200"
 msgid "Download directory"
 msgstr "Download map"
@@ -376,9 +353,7 @@ msgctxt "#30203"
 msgid "Automatically rename the video (download directory required)"
 msgstr "Hernoem de video automatisch (download map vereist)"
 
-
-# Accounts (from 30240 to 30259)
-
+# Accounts (from 30240 to 30269)
 msgctxt "#30240"
 msgid "NRJ Login"
 msgstr "NRJ gebruikersnaam"
@@ -427,51 +402,42 @@ msgctxt "#30251"
 msgid "UKTVPlay Password"
 msgstr "UKTVPlay wachtwoord"
 
-
-
 # TV integration (from 30270 to 30289)
-
 msgctxt "#30270"
 msgid "TV integration"
-msgstr ""
+msgstr "TV integratie"
 
 msgctxt "#30271"
 msgid "Kodi Live TV integration"
-msgstr ""
+msgstr "Kodi Live TV integratie"
 
 msgctxt "#30272"
 msgid "Install IPTV Manager add-on"
-msgstr ""
+msgstr "Installeer IPTV Manager add-on"
 
 msgctxt "#30273"
 msgid "Enable Kodi Live TV integration"
-msgstr ""
+msgstr "Activeer Kodi Live TV intergatie"
 
 msgctxt "#30274"
 msgid "Open IPTV Manager settings"
-msgstr ""
+msgstr "Open IPTV Manager instellingen"
 
 msgctxt "#30275"
 msgid "Select channels to enable"
-msgstr ""
+msgstr "Selecteer de kanalen om te activeren"
 
 msgctxt "#30276"
 msgid "Failed to save TV integration settings"
-msgstr ""
+msgstr "Kon de TV integratie instellingen niet opslaan"
 
 msgctxt "#30277"
 msgid "Select channels to enable in Kodi Live TV"
-msgstr ""
-
-
+msgstr "Selecteer de kanalen om te activeren in Kodi Live TV"
 
 # Reserved space for other tab/category in settins (from 30290 to 30339)
-
-
-
 # delete_for_submission_start
 # OpenVPN (from 30340 to 30369)
-
 msgctxt "#30340"
 msgid "Enable VPN feature"
 msgstr "Activeer VPN functionaliteit"
@@ -559,11 +525,9 @@ msgstr "Selecteer de te verwijderen OpenVPN configuratie"
 msgctxt "#30361"
 msgid "Connect/Disconnect VPN"
 msgstr "Verbind/Verbreek VPN"
+
 # delete_for_submission_end
-
-
 # Advanced settings (from 30370 to 30399)
-
 msgctxt "#30370"
 msgid "Clear cache"
 msgstr "Cache legen"
@@ -574,22 +538,20 @@ msgstr "Cache geleegd"
 
 msgctxt "#30372"
 msgid "Send Kodi log to the developers when an error occurred"
-msgstr ""
+msgstr "Stuur de Kodi log naar de ontwikkelaars wanneer er zich een fout voordoet"
 
 msgctxt "#30373"
 msgid "Delete favourites"
-msgstr ""
+msgstr "Verwijder favorieten"
 
 msgctxt "#30374"
 msgid "Favourites deleted"
-msgstr ""
-
+msgstr "Favorieten verwijderd"
 
 # Settings of 'General' category (from 30400 to 30429)
-
 msgctxt "#30400"
 msgid "Restore default order of all menus"
-msgstr ""
+msgstr "Herstel de standaard volgorde van alle menus"
 
 msgctxt "#30401"
 msgid "Unmask all hidden items"
@@ -601,7 +563,7 @@ msgstr ""
 
 msgctxt "#30403"
 msgid "Menu items"
-msgstr ""
+msgstr "Menu items"
 
 msgctxt "#30404"
 msgid ""
@@ -617,26 +579,19 @@ msgstr ""
 
 msgctxt "#30407"
 msgid "Default order of all menus have been restored"
-msgstr ""
+msgstr "De standaard volgorde van alle menus is hersteld"
 
 msgctxt "#30408"
 msgid "All hidden items have been unmasked"
 msgstr ""
 
-
 # Advanced settings (from 30430 to 30449)
-
 msgctxt "#30430"
 msgid "Automatically start Catch-up TV & More when Kodi starts"
-msgstr ""
-
+msgstr "Start Catch-up TV & More automatisch wanneer Kodi start"
 
 # Reserved space for other tab/category in settins (from 30450 to 30499)
-
-
-
 # Context menu (from 30500 to 30599)
-
 msgctxt "#30500"
 msgid "Move down"
 msgstr "Verplaats omlaag"
@@ -661,9 +616,7 @@ msgctxt "#30505"
 msgid "List Videos (type=episode)"
 msgstr "Videos weergeven (type=episode)"
 
-
 # Dialog boxes (from 30600 to 30699)
-
 msgctxt "#30600"
 msgid "Information"
 msgstr "Informatie"
@@ -692,9 +645,7 @@ msgctxt "#30606"
 msgid "Do you want to see this information next time?"
 msgstr "Wilt u deze informatie een volgende keer zien?"
 
-
 # Others (from 30700 to 30799)
-
 msgctxt "#30700"
 msgid "More videos..."
 msgstr "Meer video's..."
@@ -785,27 +736,25 @@ msgstr "Inhoud vereist een abonnement"
 
 msgctxt "#30722"
 msgid "TV guide"
-msgstr ""
+msgstr "Tv-gids"
 
 msgctxt "#30723"
 msgid "An error occurred while getting TV guide"
-msgstr ""
+msgstr "Er trap een fout op bij het ophalen van de Tv-gids"
 
 msgctxt "#30724"
 msgid "Failed to guess your country based on your IP"
-msgstr ""
+msgstr "Uw land kon niet bepaald worden op basis van uw IP"
 
 msgctxt "#30725"
 msgid "Categories"
-msgstr ""
+msgstr "Categoriën"
 
 msgctxt "#30726"
 msgid "Races"
-msgstr ""
-
+msgstr "Races"
 
 # Favourites (from 30800 to 30859)
-
 msgctxt "#30800"
 msgid "Add to add-on favourites"
 msgstr "Toevoegen aan add-on favorieten"
@@ -838,44 +787,40 @@ msgctxt "#30807"
 msgid "This favourite raises an error, would you like to delete it?"
 msgstr "Deze favoriet veroorzaakt een fout, wilt het verwijderen?"
 
-
 # Log uploader (from 30860 to 30889)
-
 msgctxt "#30860"
 msgid "This selection triggered an unexpected error, would you like to share your error log so that we can try to resolve this issue?"
 msgstr "Deze selectie heeft een onverwachte fout veroorzaakt, wilt u het logboek delen zodat we kunnen proberen de fout op te lossen?"
 
 msgctxt "#30861"
-msgid "Share us the URL URL_TO_REPLACE by e-mail directly via the QR-code or catch.up.tv.and.more@gmail.com or in an issue on GitHub. Thank you!"
+msgid "Share us the URL URL_TO_REPLACE by email directly via the QRcode or at catch.up.tv.and.more@gmail.com or in an issue on GitHub. Thank you!"
 msgstr "Deel met ons de URL URL_TO_REPLACE direct via e-mail via de QR-code of catch.up.tv.and.more@gmail.com of via een ticket op GitHub. Dank u wel!"
 
 msgctxt "#30862"
 msgid "Sorry, sharing your error log failed"
 msgstr "Sorry, delen van het logboek is mislukt"
 
-
 # HTTP error (from 30890 to 30919)
-
 msgctxt "#30890"
 msgid "HTTP Error code"
-msgstr ""
+msgstr "HTTP foutcode"
 
 msgctxt "#30891"
 msgid "Inaccessible content"
-msgstr ""
+msgstr "Ontoegankelijke inhoud"
 
 msgctxt "#30892"
 msgid "Authentication is required to access the resource"
-msgstr ""
+msgstr "Authenticatie is nodig voor deze bron"
 
 msgctxt "#30893"
 msgid "Access denied (Geographical restriction?)"
-msgstr ""
+msgstr "Toegang geweigerd (geografische beperking?)"
 
 msgctxt "#30894"
 msgid "This resource requires a payment or a subscription"
-msgstr ""
+msgstr "Deze bron vereist een betaling of abonnement"
 
 msgctxt "#30895"
 msgid "This resource is no longer available"
-msgstr ""
+msgstr "Deze bron is niet langer beschikbaar"

--- a/tools/check_for_unused_translations.py
+++ b/tools/check_for_unused_translations.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+""" Quick and dirty way to check if all translations might be used. """
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+# pylint: disable=invalid-name,superfluous-parens
+
+import subprocess
+import sys
+
+import polib
+
+error = 0
+
+# Load all python code from git
+code = subprocess.check_output(['git', 'grep', '', '--', 'resources/*.py', 'resources/settings.xml', 'addon.xml']).decode('utf-8')
+
+# Load po file
+po = polib.pofile('resources/language/resource.language.en_gb/strings.po')
+for entry in po:
+
+    # Skip empty translations
+    if entry.msgid == '':
+        continue
+
+    # Extract msgctxt
+    msgctxt = entry.msgctxt.lstrip('#')
+
+    if msgctxt not in code:
+        print('No usage found for translation:')
+        print(entry)
+        error = 1
+
+sys.exit(error)

--- a/tools/update_translations.py
+++ b/tools/update_translations.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# pylint: disable=missing-docstring,no-self-use,wrong-import-order,wrong-import-position,invalid-name
+
+import sys
+from glob import glob
+
+import polib
+
+original_file = 'resources/language/resource.language.en_gb/strings.po'
+original = polib.pofile(original_file, wrapwidth=0)
+
+for translated_file in glob('resources/language/resource.language.*/strings.po'):
+
+    # Skip original file
+    if translated_file == original_file:
+        continue
+
+    print('Updating %s...' % translated_file)
+
+    # Load po-files
+    translated = polib.pofile(translated_file, wrapwidth=0)
+
+    for entry in original:
+        # Find a translation
+        translation = translated.find(entry.msgctxt, 'msgctxt')
+
+        if translation and entry.msgid == translation.msgid:
+            entry.msgstr = translation.msgstr
+
+    original.metadata = translated.metadata
+
+    if sys.platform.startswith('win'):
+        # On Windows save the file keeping the Linux return character
+        with open(translated_file, 'wb') as _file:
+            content = str(original).encode('utf-8')
+            content = content.replace(b'\r\n', b'\n')
+            _file.write(content)
+    else:
+        # Save it now over the translation
+        original.save(translated_file)


### PR DESCRIPTION
* Add scripts to update translations (see below for more info).
* Add missing NL translations.
* Fix wrong translated FR value.

## Added scripts
* You can run `tools/update_translations.py` to update the other languages when new translations have been added or modified in the english base file.

* You can run `tools/check_for_unused_translations.py` to check the codebase for the msgctxt values. If an msgctxt doesn't exist in the codebase, it's probably not in use anymore and could be removed. I haven't done this yet in this PR. There are quite a lot of them. See [unused_translations.txt](https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/files/6196176/unused_translations.txt)
