### PR TITLE
Fix 6play replay issue

### DIFF
--- a/resources/lib/channels/fr/6play.py
+++ b/resources/lib/channels/fr/6play.py
@@ -433,7 +433,13 @@ def get_video_url(plugin,
     for asset in video_assets:
         if 'usp_dashcenc_h264' in asset["type"]:
             item = Listitem()
-            item.path = asset['full_physical_path']
+            dummy_req = urlquick.get(
+                                        asset['full_physical_path'],
+                                        headers={'User-Agent': web_utils.get_random_ua()},
+                                        allow_redirects=False
+                                    )
+            playback_url = dummy_req.headers['location']
+            item.path = playback_url
             if 'http' in subtitle_url:
                 item.subtitles.append(subtitle_url)
             item.label = get_selected_item_label()


### PR DESCRIPTION
This PR fixes replay issue on 6play's video opened [here](https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/issues/510)
As mentioned by inputstream adaptive the mpd manifest does not contain a base URL therefore inputstream adaptive is defaulting to the provided item path base URL which become outdated after the redirection.
Solution download the manifest catch to redirect URL from the location response header and feed that to inputstream adaptive