### PR TITLE
Fix TVE stream url

### DIFF
--- a/resources/lib/channels/es/rtve.py
+++ b/resources/lib/channels/es/rtve.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+    # -*- coding: utf-8 -*-
 # Copyright: (c) 2016-2020, Team Catch-up TV & More
 # GNU General Public License v2.0+ (see LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt)
 
@@ -16,7 +16,7 @@ from resources.lib.menu_utils import item_post_treatment
 
 URL_ROOT = 'https://www.rtve.es'
 
-URL_LIVE_STREAM = 'https://rtvelivestream-lvlt.rtve.es/%s_dvr.m3u8'
+URL_LIVE_STREAM = 'https://rtvelivestream.akamaized.net/%s_main_dvr.m3u8'
 # Live Id
 
 URL_CATEGORIES = URL_ROOT + '/alacarta/categorieslist.shtml?ctx=tve'


### PR DESCRIPTION
Bonjour,

L'url de streaming pour le live des chaines espagnoles du groupe TVE (La1, La2, TDP y 24h) ne fonctionne pas correctement chez moi. Le lien suivant indique des urls qui fonctionnent beaucoup mieux (en tout cas chez moi) : https://github.com/LaQuay/TDTChannels

J'ai fait la correction pour TVE mais certains chaines pourraient être ajoutées pour l'espagne (mais il faudrait les tester avant car elles ne sont pas toutes fonctionnelles ou pertinentes).

C'est ma première contribution et j'espère vous aider un peu plus à l'avenir en fonction de mes disponibilités ... si ça vous convient. Sinon, c'est un super addon, merci à tous pour le travail derrière. :<)
