### PR TITLE
RTBF hardcode live url if it contains DRM

### DIFF
--- a/resources/lib/channels/be/rtbf.py
+++ b/resources/lib/channels/be/rtbf.py
@@ -595,14 +595,22 @@ def set_live_url(plugin, item_id, **kwargs):
     if "url_streaming" in json_parser:
         is_drm = json_parser["drm"]
         if is_drm:
-            #if 'url_hls' in json_parser["url_streaming"]:
-            #    live_url = json_parser["url_streaming"]["url_hls"]
-            #    if "_drm.m3u8" in live_url:
-            #        live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
-            #    live_id = json_parser["id"]
-            #    is_drm = False
-            #elif 'url_dash' in json_parser["url_streaming"]:
-            if 'url_dash' in json_parser["url_streaming"]:
+            if 'url_hls' in json_parser["url_streaming"]:
+                live_url = json_parser["url_streaming"]["url_hls"]
+                if "_drm.m3u8" in live_url:
+                    live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
+                if "/.m3u8?" in live_url:
+                    if "laune" in live_url:
+                        live_url = URL_LIVE_LAUNE
+                    elif "ladeux" in live_url:
+                        live_url = URL_LIVE_LADEUX
+                    elif "ladeux" in live_url:
+                        live_url = URL_LIVE_LATROIS
+                    else:
+                        live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
+                live_id = json_parser["id"]
+                is_drm = False
+            elif 'url_dash' in json_parser["url_streaming"]:
                 live_url = json_parser["url_streaming"]["url_dash"]
                 live_id = json_parser["id"]
             else:

--- a/resources/lib/channels/be/rtbf.py
+++ b/resources/lib/channels/be/rtbf.py
@@ -595,13 +595,14 @@ def set_live_url(plugin, item_id, **kwargs):
     if "url_streaming" in json_parser:
         is_drm = json_parser["drm"]
         if is_drm:
-            if 'url_hls' in json_parser["url_streaming"]:
-                live_url = json_parser["url_streaming"]["url_hls"]
-                if "_drm.m3u8" in live_url:
-                    live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
-                live_id = json_parser["id"]
-                is_drm = False
-            elif 'url_dash' in json_parser["url_streaming"]:
+            #if 'url_hls' in json_parser["url_streaming"]:
+            #    live_url = json_parser["url_streaming"]["url_hls"]
+            #    if "_drm.m3u8" in live_url:
+            #        live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
+            #    live_id = json_parser["id"]
+            #    is_drm = False
+            #elif 'url_dash' in json_parser["url_streaming"]:
+            if 'url_dash' in json_parser["url_streaming"]:
                 live_url = json_parser["url_streaming"]["url_dash"]
                 live_id = json_parser["id"]
             else:

--- a/resources/lib/channels/be/rtbf.py
+++ b/resources/lib/channels/be/rtbf.py
@@ -73,7 +73,9 @@ URL_JSON_LIVE_CHANNEL = 'http://www.rtbf.be/api/partner/generic/live/' \
 URL_LICENCE_KEY = 'https://wv-keyos.licensekeyserver.com/|%s|R{SSM}|'
 
 URL_TOKEN = 'https://www.rtbf.be/api/partner/generic/drm/encauthxml?%s=%s&partner_key=%s'
-
+URL_LIVE_LAUNE = 'https://rtbf-live.fl.freecaster.net/live/rtbf/geo/drm/laune_aes.m3u8'
+URL_LIVE_LADEUX = 'https://rtbf-live.fl.freecaster.net/live/rtbf/geo/drm/ladeux_aes.m3u8'
+URL_LIVE_LATROIS = 'https://rtbf-live.fl.freecaster.net/live/rtbf/geo/drm/latrois_aes.m3u8'
 
 URL_ROOT_LIVE = 'https://www.rtbf.be/auvio/direct#/'
 
@@ -643,7 +645,14 @@ def list_lives(plugin, item_id, **kwargs):
                 if 'url_hls' in live_datas["url_streaming"]:
                     live_url = live_datas["url_streaming"]["url_hls"]
                     if "_drm.m3u8" in live_url:
-                        live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
+                        if "laune" in live_url:
+                            live_url = URL_LIVE_LAUNE
+                        elif "ladeux" in live_url:
+                            live_url = URL_LIVE_LADEUX
+                        elif "ladeux" in live_url:
+                            live_url = URL_LIVE_LATROIS
+                        else:
+                            live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
                     live_id = live_datas["id"]
                     is_drm = False
                 elif 'url_dash' in live_datas["url_streaming"]:

--- a/resources/lib/channels/be/rtbf.py
+++ b/resources/lib/channels/be/rtbf.py
@@ -602,9 +602,9 @@ def set_live_url(plugin, item_id, **kwargs):
                 if "/.m3u8?" in live_url:
                     if "laune" in live_url:
                         live_url = URL_LIVE_LAUNE
-                    elif "ladeux" in live_url:
+                    elif "tipik" in live_url:
                         live_url = URL_LIVE_LADEUX
-                    elif "ladeux" in live_url:
+                    elif "latrois" in live_url:
                         live_url = URL_LIVE_LATROIS
                     else:
                         live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
@@ -658,9 +658,9 @@ def list_lives(plugin, item_id, **kwargs):
                     if "/.m3u8?" in live_url:
                         if "laune" in live_url:
                             live_url = URL_LIVE_LAUNE
-                        elif "ladeux" in live_url:
+                        elif "tipik" in live_url:
                             live_url = URL_LIVE_LADEUX
-                        elif "ladeux" in live_url:
+                        elif "latrois" in live_url:
                             live_url = URL_LIVE_LATROIS
                         else:
                             live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')

--- a/resources/lib/channels/be/rtbf.py
+++ b/resources/lib/channels/be/rtbf.py
@@ -645,6 +645,8 @@ def list_lives(plugin, item_id, **kwargs):
                 if 'url_hls' in live_datas["url_streaming"]:
                     live_url = live_datas["url_streaming"]["url_hls"]
                     if "_drm.m3u8" in live_url:
+                        live_url = live_url.replace('_drm.m3u8', '_aes.m3u8')
+                    if "/.m3u8?" in live_url:
                         if "laune" in live_url:
                             live_url = URL_LIVE_LAUNE
                         elif "ladeux" in live_url:


### PR DESCRIPTION
Live aren't working anymore because they are passing by an ad service and we can't change the SAMPLE-AES by the AES-128 file...I have hardcoded the URL that is working but I don't know how long it will continue to work.