### PR TITLE
Fix MYTF1 video types to upper case

### DIFF
--- a/resources/lib/channels/fr/mytf1.py
+++ b/resources/lib/channels/fr/mytf1.py
@@ -37,9 +37,9 @@ URL_API = 'https://www.tf1.fr/graphql/web'
 DESIRED_QUALITY = Script.setting['quality']
 
 VIDEO_TYPES = {
-    'Replay': 'replay',
-    'Extrait': 'extract',
-    'Exclu': 'bonus'
+    'Replay': 'REPLAY',
+    'Extrait': 'EXTRACT',
+    'Exclu': 'BONUS'
 }
 
 


### PR DESCRIPTION
Change MYTF1 video types from lower case to upper case because of change in MyTF1 API

Fixes #562 