### PR TITLE
Recommended way of importing MutableMapping

### DIFF
--- a/resources/lib/mem_storage.py
+++ b/resources/lib/mem_storage.py
@@ -11,7 +11,7 @@ try:
     import pickle as pickle
 except ImportError:
     import pickle
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from six import string_types
 from kodi_six import xbmcgui
 


### PR DESCRIPTION
```python
from collections import MutableMapping
```
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working