### PR TITLE
[PL - Live TVP] fix URLs, gracefully handle not available streams, rename /TVP Poland In/ to /TVP World/

### DIFF
--- a/resources/lib/channels/pl/tvp.py
+++ b/resources/lib/channels/pl/tvp.py
@@ -74,4 +74,4 @@ def get_live_url(plugin, item_id, **kwargs):
     lives_html = urlquick.get(URL_STREAM % live_id,
                               headers={'User-Agent': web_utils.get_random_ua()},
                               max_age=-1)
-    return re.compile(r'src:\'(.*?)\'').findall(lives_html.text)[0]
+    return re.compile(r'src:\'(.+\.m3u8)\'').findall(lives_html.text)[0]

--- a/resources/lib/channels/pl/tvp.py
+++ b/resources/lib/channels/pl/tvp.py
@@ -59,7 +59,8 @@ def get_live_url(plugin, item_id, **kwargs):
                     live_id = live_datas.get('data-video-id')
                     break
             elif item_id == 'tvppolonia':
-                if 'Polonia' in live_datas.get('data-title'):
+                if ('Polonia' in live_datas.get('data-title')) or
+                   ('1773' in live_datas.get('data-channel-id')):
                     live_id = live_datas.get('data-video-id')
                     break
             elif item_id == 'tvpworld':

--- a/resources/lib/channels/pl/tvp.py
+++ b/resources/lib/channels/pl/tvp.py
@@ -62,7 +62,7 @@ def get_live_url(plugin, item_id, **kwargs):
                 if 'Polonia' in live_datas.get('data-title'):
                     live_id = live_datas.get('data-video-id')
                     break
-            elif item_id == 'tvppolandin':
+            elif item_id == 'tvpworld':
                 if 'News and entertainment' in live_datas.get('data-title'):
                     live_id = live_datas.get('data-video-id')
                     break

--- a/resources/lib/skeletons/pl_live.py
+++ b/resources/lib/skeletons/pl_live.py
@@ -48,11 +48,11 @@ menu = {
         'enabled': True,
         'order': 4
     },
-    'tvppolandin': {
+    'tvpworld': {
         'resolver': '/resources/lib/channels/pl/tvp:get_live_url',
-        'label': 'TVP Poland IN',
-        'thumb': 'channels/pl/tvppolandin.png',
-        'fanart': 'channels/pl/tvppolandin_fanart.jpg',
+        'label': 'TVP World',
+        'thumb': 'channels/pl/tvpworld.png',
+        'fanart': 'channels/pl/tvpworld_fanart.jpg',
         'enabled': True,
         'order': 5
     }


### PR DESCRIPTION
List of changes:
* [fix(live-pl): search specifically for .m3u8 URLs](https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/commit/d5f8151d7c32262fbf2388ee03dd1430d744baee)
* [fix(live-pl): gracefully handle not available streams](https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/commit/27e5c7bb124fda1326ccca88896fa0b1d2b0fb34)
* [chore(live-pl): rename 'TVP Poland In' to 'TVP World'](https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/commit/775162832937c164d18dd914e2bb005d7ec0cc25)
* [fix(live-pl): additionally use `data-channel-id` for 'Polonia'](https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/commit/a44979d23d9c626b5d8849681dcd3813abc34c2d)

:information_source: Changes have been tested on Kodi 18 on Linux/x86_64 and CoreElec/Odroid-C2.

:warning: Note: this PR has a dependency on updating associated artwork for _TVP World_:
-> https://github.com/Catch-up-TV-and-More/resource.images.catchuptvandmore/pull/6