### PR TITLE
[PL - TVP] correct linting on `tvp.py` for Flake8

### DIFF
--- a/resources/lib/channels/pl/tvp.py
+++ b/resources/lib/channels/pl/tvp.py
@@ -59,8 +59,10 @@ def get_live_url(plugin, item_id, **kwargs):
                     live_id = live_datas.get('data-video-id')
                     break
             elif item_id == 'tvppolonia':
-                if ('Polonia' in live_datas.get('data-title')) or
-                   ('1773' in live_datas.get('data-channel-id')):
+                if (
+                    'Polonia' in live_datas.get('data-title')
+                    or '1773' in live_datas.get('data-channel-id')
+                ):
                     live_id = live_datas.get('data-video-id')
                     break
             elif item_id == 'tvpworld':


### PR DESCRIPTION
:bug:  Correct a linting issue introduced with https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/commit/2a0dbbc1bae28af00f20864fad7cd8f5de6a4ca4.
This change has been tested against latest version of Flake8, no more violations for on `tvp.py` :+1: 