### PR TITLE
[SG - CNA]: correct linting on `cna.py` for Flake8

### DIFF
--- a/resources/lib/channels/sg/cna.py
+++ b/resources/lib/channels/sg/cna.py
@@ -17,6 +17,7 @@ URL_ROOT = "https://www.channelnewsasia.com"
 
 URL_LIVE = URL_ROOT + "/watch"
 
+
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
 


### PR DESCRIPTION
Fixes following Flake8 violation:
> resources/lib/channels/sg/cna.py:20:1: E302 expected 2 blank lines, found 1