### PR TITLE
[BE - RTLPLAY] correct linting on `rtlplaybe.py` for Flake8

### DIFF
--- a/resources/lib/channels/be/rtlplaybe.py
+++ b/resources/lib/channels/be/rtlplaybe.py
@@ -137,7 +137,7 @@ def list_videos_search(plugin, search_query, item_id, page, **kwargs):
     if search_query is None or len(search_query) == 0:
         return False
 
-    json_body_template = """ 
+    json_body_template = """
     {
         "requests": [
             {


### PR DESCRIPTION
Fixes following Flake8 violation:
> ./resources/lib/channels/be/rtlplaybe.py:140:4: W291 trailing whitespace