### PR TITLE
[BE - ABBE] correct linting on `abbe.py` for Flake8

### DIFF
--- a/resources/lib/channels/be/abbe.py
+++ b/resources/lib/channels/be/abbe.py
@@ -148,7 +148,7 @@ def get_live_url(plugin, item_id, **kwargs):
     }
     resp4 = session_urlquick.get(URL_API % (item_id, item_id), headers=headers, max_age=-1)
     json_parser4 = json.loads(resp4.text)
-    
+
     is_helper = inputstreamhelper.Helper("mpd")
     if not is_helper.check_inputstream():
         return False


### PR DESCRIPTION
Fixes following Flake8 violation:
> ./resources/lib/channels/be/abbe.py:151:1: W293 blank line contains whitespace