### PR TITLE
[WO - ARTE] correct linting on `arte.py` for Flake8

### DIFF
--- a/resources/lib/channels/wo/arte.py
+++ b/resources/lib/channels/wo/arte.py
@@ -171,6 +171,7 @@ def get_video_url(plugin,
                                                 video_id,
                                                 download_mode)
 
+
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
     final_language = kwargs.get('language', DESIRED_LANGUAGE)


### PR DESCRIPTION
Fixes following Flake8 violation:
> ./resources/lib/channels/wo/arte.py:174:1: E302 expected 2 blank lines, found 1