### PR TITLE
[ES - REALMADRIDTV] correct linting on `realmadridtv.py` for Flake8

### DIFF
--- a/resources/lib/channels/es/realmadridtv.py
+++ b/resources/lib/channels/es/realmadridtv.py
@@ -8,7 +8,8 @@ from __future__ import unicode_literals
 import re
 
 from codequick import Resolver, Script
-import urlquick, json
+import json
+import urlquick
 
 from resources.lib import web_utils
 
@@ -23,17 +24,17 @@ URL_REFERER = URL_ROOT + '/real-madrid-tv'
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
 
-    #obtain language key as lower letter
+    # Obtain language key as lower letter
     final_language = kwargs.get('language', Script.setting['realmadridtv.language']).lower()
 
-    #Get m3u8 url in a json
+    # Get m3u8 url in a json
     resp = urlquick.get(URL_LIVE,
-                        headers={'referer':URL_REFERER},
+                        headers={'referer': URL_REFERER},
                         max_age=-1)
 
     # Parse json, format : {'vurl': {'es':url,'en':url}}
-    resp_json=json.loads(resp.text)
+    resp_json = json.loads(resp.text)
 
-    url_live=resp_json['vurl'][final_language]
+    url_live = resp_json['vurl'][final_language]
 
     return url_live


### PR DESCRIPTION
Fixes following Flake8 violations:
> ./resources/lib/channels/es/realmadridtv.py:11:16: E401 multiple imports on one line
> ./resources/lib/channels/es/realmadridtv.py:26:5: E265 block comment should start with '# '
> ./resources/lib/channels/es/realmadridtv.py:29:5: E265 block comment should start with '# '
> ./resources/lib/channels/es/realmadridtv.py:31:43: E231 missing whitespace after ':'
> ./resources/lib/channels/es/realmadridtv.py:35:14: E225 missing whitespace around operator
> ./resources/lib/channels/es/realmadridtv.py:37:13: E225 missing whitespace around operator