### PR TITLE
[FR - TNTV] correct linting on `tntv.py` for Flake8

### DIFF
--- a/resources/lib/channels/fr/tntv.py
+++ b/resources/lib/channels/fr/tntv.py
@@ -17,15 +17,15 @@ URL_ROOT = "https://www.tntv.pf/"
 
 URL_LIVE = URL_ROOT + "/direct"
 
+
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE, headers={'User-Agent': web_utils.get_random_ua()}, max_age=-1)
-    root = resp.parse()
-    
+
     data_account_player = re.search('//players\.brightcove\.net/([0-9]+)/([A-Za-z0-9]+)_default/index\.html\?videoId=([0-9]+)', resp.text)
     data_account = data_account_player.group(1)
     data_player = data_account_player.group(2)
     data_video_id = data_account_player.group(3)
-    
+
     return resolver_proxy.get_brightcove_video_json(plugin, data_account, data_player, data_video_id)


### PR DESCRIPTION
Fixes following Flake8 violations:
> ./resources/lib/channels/fr/tntv.py:20:1: E302 expected 2 blank lines, found 1
> ./resources/lib/channels/fr/tntv.py:24:5: F841 local variable 'root' is assigned to but never used
> ./resources/lib/channels/fr/tntv.py:25:1: W293 blank line contains whitespace
> ./resources/lib/channels/fr/tntv.py:30:1: W293 blank line contains whitespace