### PR TITLE
[WO - TV5Monde] correct linting on `tv5monde.py` for Flake8

### DIFF
--- a/resources/lib/channels/wo/tv5monde.py
+++ b/resources/lib/channels/wo/tv5monde.py
@@ -15,7 +15,7 @@ from codequick import Listitem, Resolver, Route
 from resources.lib import download, web_utils
 from resources.lib.menu_utils import item_post_treatment
 from resources.lib.kodi_utils import (INPUTSTREAM_PROP, get_selected_item_art,
-    get_selected_item_info, get_selected_item_label)
+                                      get_selected_item_info, get_selected_item_label)
 
 # TODO Rework filter for all videos
 


### PR DESCRIPTION
Fixes following Flake8 violation:
> ./resources/lib/channels/wo/tv5monde.py:18:5: E128 continuation line under-indented for visual indent

And after this PR has been merged, and PR #648 has been merged, there will be be more Flake8 violations! :tada: :partying_face: 
See: https://github.com/ppiotr3k/plugin.video.catchuptvandmore/runs/5351956143

Would be then a great time to fix CI in order not to allow new violations to get in silently,  :wink: 
and all in all allow a greater Dev Experience with the project :relaxed: 