### PR TITLE
resolver_proxy : get_stream_with_quality

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -64,7 +64,7 @@ msgid "Hide channels"
 msgstr ""
 
 msgctxt "#30012"
-msgid "To configure YTDL go settings of script.module.youtube.dl"
+msgid "YTDL settings"
 msgstr ""
 
 msgctxt "#30013"
@@ -288,7 +288,7 @@ msgid "Video quality"
 msgstr ""
 
 msgctxt "#30151"
-msgid "Video quality (BEST|DEFAULT|DIALOG)"
+msgid "Video quality (BEST|DEFAULT|DIALOG|WORST)"
 msgstr ""
 
 msgctxt "#30152"
@@ -383,6 +383,10 @@ msgctxt "#30175"
 msgid "Equidia Racing: Choose race"
 msgstr ""
 
+msgctxt "#30196"
+msgid "Maximum stream bitrate [COLOR=gray](0=disabled)[/COLOR]"
+msgstr ""
+
 msgctxt "#30197"
 msgid "Settings - InputStream adaptive"
 msgstr ""
@@ -392,7 +396,7 @@ msgid "Use inputstream HLS?"
 msgstr ""
 
 msgctxt "#30199"
-msgid "Use ytdl for live?"
+msgid "Use ytdl for stream?"
 msgstr ""
 
 # Download (from 30200 to 30239)

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -64,8 +64,8 @@ msgid "Hide channels"
 msgstr "Masquer des chaînes"
 
 msgctxt "#30012"
-msgid "To configure YTDL go settings of script.module.youtube.dl"
-msgstr "Pour configurer YTDL aller dans la configuration de script.module.youtube.dl"
+msgid "YTDL settings"
+msgstr "Paramètres YTDL"
 
 msgctxt "#30013"
 msgid "Hide countries"
@@ -288,8 +288,8 @@ msgid "Video quality"
 msgstr "Qualité vidéo"
 
 msgctxt "#30151"
-msgid "Video quality (BEST|DEFAULT|DIALOG)"
-msgstr "Qualité vidéo (BEST|DEFAULT|DIALOG)"
+msgid "Video quality (BEST|DEFAULT|DIALOG|WORST)"
+msgstr "Qualité vidéo (BEST|DEFAULT|DIALOG|WORST)"
 
 msgctxt "#30152"
 msgid "Contents"
@@ -383,6 +383,10 @@ msgctxt "#30175"
 msgid "Equidia Racing: Choose race"
 msgstr "Equidia Racing: Choix de la course"
 
+msgctxt "#30196"
+msgid "Maximum stream bitrate [COLOR=gray](0=disabled)[/COLOR]"
+msgstr "Bitrate max des flux [COLOR=gray](0=désactivé)[/COLOR]"
+
 msgctxt "#30197"
 msgid "Settings - InputStream adaptive"
 msgstr "Paramètres - InputStream adaptive"
@@ -392,8 +396,8 @@ msgid "Use inputstream HLS?"
 msgstr "Utiliser inputstream HLS ?"
 
 msgctxt "#30199"
-msgid "Use ytdl for live?"
-msgstr "Utiliser ytdl pour le live ?"
+msgid "Use ytdl for stream?"
+msgstr "Utiliser ytdl pour le flux ?"
 
 # Download (from 30200 to 30239)
 

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -64,8 +64,8 @@ msgid "Hide channels"
 msgstr ""
 
 msgctxt "#30012"
-msgid "To configure YTDL go settings of script.module.youtube.dl"
-msgstr "כדי לקבוע את התצורה של YTDL עבור אל ההגדרות של script.module.youtube.dl"
+msgid "YTDL settings"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Hide countries"
@@ -288,8 +288,8 @@ msgid "Video quality"
 msgstr "איכות וידאו מיו-טיוב"
 
 msgctxt "#30151"
-msgid "Video quality (BEST|DEFAULT|DIALOG)"
-msgstr "איכות וידאו (הטוב ביותר|ברירת מחדל|תיבת דו-שיח)"
+msgid "Video quality (BEST|DEFAULT|DIALOG|WORST)"
+msgstr ""
 
 msgctxt "#30152"
 msgid "Contents"
@@ -383,6 +383,10 @@ msgctxt "#30175"
 msgid "Equidia Racing: Choose race"
 msgstr ""
 
+msgctxt "#30196"
+msgid "Maximum stream bitrate [COLOR=gray](0=disabled)[/COLOR]"
+msgstr ""
+
 msgctxt "#30197"
 msgid "Settings - InputStream adaptive"
 msgstr ""
@@ -392,7 +396,7 @@ msgid "Use inputstream HLS?"
 msgstr ""
 
 msgctxt "#30199"
-msgid "Use ytdl for live?"
+msgid "Use ytdl for stream?"
 msgstr ""
 
 # Download (from 30200 to 30239)

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -64,8 +64,8 @@ msgid "Hide channels"
 msgstr "Verberg kanalen"
 
 msgctxt "#30012"
-msgid "To configure YTDL go settings of script.module.youtube.dl"
-msgstr "Ga naar de instellingen van script.module.youtube.dl om YTDL te configureren"
+msgid "YTDL settings"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Hide countries"
@@ -288,8 +288,8 @@ msgid "Video quality"
 msgstr "Video kwaliteit"
 
 msgctxt "#30151"
-msgid "Video quality (BEST|DEFAULT|DIALOG)"
-msgstr "Video kwaliteit (BEST|DEFAULT|DIALOG)"
+msgid "Video quality (BEST|DEFAULT|DIALOG|WORST)"
+msgstr "Video kwaliteit (BEST|DEFAULT|DIALOG|WORST)"
 
 msgctxt "#30152"
 msgid "Contents"
@@ -383,6 +383,10 @@ msgctxt "#30175"
 msgid "Equidia Racing: Choose race"
 msgstr ""
 
+msgctxt "#30196"
+msgid "Maximum stream bitrate [COLOR=gray](0=disabled)[/COLOR]"
+msgstr ""
+
 msgctxt "#30197"
 msgid "Settings - InputStream adaptive"
 msgstr ""
@@ -392,7 +396,7 @@ msgid "Use inputstream HLS?"
 msgstr ""
 
 msgctxt "#30199"
-msgid "Use ytdl for live?"
+msgid "Use ytdl for stream?"
 msgstr ""
 
 # Download (from 30200 to 30239)

--- a/resources/lib/addon_utils.py
+++ b/resources/lib/addon_utils.py
@@ -81,11 +81,14 @@ def get_quality_YTDL(download_mode=False):
             return 3
 
         if quality == 'DIALOG':
-            youtubeDL_qualiy = ['SD', '720p', '1080p', 'Highest Available']
+            youtube_dl_quality = ['SD', '720p', '1080p', 'Highest Available']
             selected_item = xbmcgui.Dialog().select(
                 Script.localize(30709),
-                youtubeDL_qualiy)
+                youtube_dl_quality)
             return selected_item
+
+        if quality == 'WORST':
+            return 0
 
         return 3
 

--- a/resources/lib/channels/be/bouke.py
+++ b/resources/lib/channels/be/bouke.py
@@ -115,7 +115,7 @@ def play_video(plugin, url):
         return False
     video_url = m3u8_array[0].replace("\\", "")
 
-    return resolver_proxy.get_stream_ia_or_default(plugin, video_url=video_url, manifest_type="hls")
+    return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url, manifest_type="hls")
 
 
 @Resolver.register
@@ -132,4 +132,4 @@ def get_live_url(plugin, item_id, **kwargs):
         return False
     video_url = m3u8_array[0].replace("\\", "")
 
-    return resolver_proxy.get_stream_ia_or_default(plugin, video_url=video_url, manifest_type="hls")
+    return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url, manifest_type="hls")

--- a/resources/lib/channels/be/rtbf.py
+++ b/resources/lib/channels/be/rtbf.py
@@ -553,7 +553,7 @@ def get_video_url(plugin,
         return item
 
     if video_url.endswith('m3u8'):
-        return resolver_proxy.get_stream_ia_or_default(plugin, video_url=video_url, manifest_type="hls")
+        return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url, manifest_type="hls")
 
     return video_url
 
@@ -584,7 +584,7 @@ def get_video_url2(plugin,
         return download.download_video(stream_url)
 
     if stream_url.endswith('m3u8'):
-        return resolver_proxy.get_stream_ia_or_default(plugin, video_url=stream_url, manifest_type="hls")
+        return resolver_proxy.get_stream_with_quality(plugin, video_url=stream_url, manifest_type="hls")
 
     return stream_url
 

--- a/resources/lib/channels/be/rtlplaybe.py
+++ b/resources/lib/channels/be/rtlplaybe.py
@@ -635,6 +635,14 @@ def get_final_video_url(plugin, video_assets, asset_type=None):
             i = i + 1
         final_video_url = url_best
 
+    elif desired_quality == "WORST":
+        final_video_url = all_datas_videos_path[0]
+        i = 0
+        for data_video in all_datas_videos_quality:
+            if 'lq' in data_video:
+                final_video_url = all_datas_videos_path[i]
+                return final_video_url
+
     return final_video_url
 
 

--- a/resources/lib/channels/be/telemb.py
+++ b/resources/lib/channels/be/telemb.py
@@ -104,4 +104,4 @@ def get_live_url(plugin, item_id, **kwargs):
 
     url = m3u8_files[0].replace("\\", "")
 
-    return resolver_proxy.get_stream_ia_or_default(plugin, video_url=url, manifest_type="hls")
+    return resolver_proxy.get_stream_with_quality(plugin, video_url=url, manifest_type="hls")

--- a/resources/lib/channels/be/tvlux.py
+++ b/resources/lib/channels/be/tvlux.py
@@ -137,4 +137,4 @@ def get_live_url(plugin, item_id, **kwargs):
         plugin.notify(plugin.localize(30600), plugin.localize(30716))
         return False
     url = found_m3u8_objects[0].replace('\\', '')
-    return resolver_proxy.get_stream_ia_or_default(plugin, video_url=url, manifest_type="hls")
+    return resolver_proxy.get_stream_with_quality(plugin, video_url=url, manifest_type="hls")

--- a/resources/lib/channels/ca/icirdi.py
+++ b/resources/lib/channels/ca/icirdi.py
@@ -25,4 +25,4 @@ def get_live_url(plugin, item_id, **kwargs):
 
     resp = urlquick.get(URL_LIVE)
     json_parser = json.loads(resp.text)
-    return resolver_proxy.get_stream_ia_or_default(plugin, video_url=json_parser["url"], manifest_type="hls")
+    return resolver_proxy.get_stream_with_quality(plugin, video_url=json_parser["url"], manifest_type="hls")

--- a/resources/lib/channels/ch/latele.py
+++ b/resources/lib/channels/ch/latele.py
@@ -42,4 +42,4 @@ def get_live_url(plugin, item_id, **kwargs):
     #     "referrer": "https://latele.ch/"
     # }
 
-    return resolver_proxy.get_stream_ia_or_default(plugin, video_url=URL_LIVE_M3U8, manifest_type="hls")
+    return resolver_proxy.get_stream_with_quality(plugin, video_url=URL_LIVE_M3U8, manifest_type="hls")

--- a/resources/lib/channels/fr/6play.py
+++ b/resources/lib/channels/fr/6play.py
@@ -509,6 +509,14 @@ def get_final_video_url(plugin, video_assets, asset_type=None):
             i = i + 1
         final_video_url = url_best
 
+    elif desired_quality == "WORST":
+        final_video_url = all_datas_videos_path[0]
+        i = 0
+        for data_video in all_datas_videos_quality:
+            if 'lq' in data_video:
+                final_video_url = all_datas_videos_path[i]
+                return final_video_url
+
     return final_video_url
 
 

--- a/resources/lib/channels/it/rtl.py
+++ b/resources/lib/channels/it/rtl.py
@@ -79,4 +79,4 @@ def list_lives(plugin, item_id, **kwargs):
 
 @Resolver.register
 def get_live_url(plugin, url, **kwargs):
-    return resolver_proxy.get_stream_ia_or_default(plugin, video_url=url, manifest_type="hls")
+    return resolver_proxy.get_stream_with_quality(plugin, video_url=url, manifest_type="hls")

--- a/resources/lib/streams/m3u8.py
+++ b/resources/lib/streams/m3u8.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, darodi
+# GNU General Public License v2.0+ (see LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt)
+
+# This file is part of Catch-up TV & More
+
+from __future__ import unicode_literals
+
+import re
+
+import xbmcgui
+# noinspection PyUnresolvedReferences
+from codequick import Script
+import urlquick
+
+from resources.lib.streams.mediastream import MediaStream
+
+TYPE_INDEX = 0
+BITRATE_INDEX = 1
+ID_INDEX = 2
+RESOLUTION_INDEX = 2
+URL_INDEX = 3
+
+# add an offset to include the selected bitrate, we should have more than the bitrate found
+BITRATE_OFFSET = 100
+
+
+class M3u8(object):
+    # EXT-X-STREAM-INF:BANDWIDTH=1888000,CODECS="avc1.4d481f,mp4a.40.2",RESOLUTION=1024x576
+    # PATTERN_RESOLUTIONS = re.compile(r'#EXT-X-STREAM-INF:.*RESOLUTION=([^\n]*)\n(.*\.m3u8)')
+    PATTERN_STREAMS = re.compile(
+        r"(#\w[^:]+)[^\n]+BANDWIDTH=(\d+)\d{3}[^\n]*RESOLUTION=(\d+x\d+)[^\n]*\W+([^\n]+.m3u8[^\n\r]*)")
+    PATTERN_AUDIO1 = re.compile(r'(#\w[^:]+):TYPE=AUDIO()[^\r\n]+ID="([^"]+)"[^\n\r]+URI="([^"]+.m3u8[^"]*)"')
+    PATTERN_AUDIO2 = re.compile(
+        r'(#\w[^:]+)[^\n]+BANDWIDTH=(\d+)\d{3}(?:[^\r\n]*AUDIO="([^"]+)")?[^\n]*\W+([^\n]+.m3u8[^\n\r]*)')
+
+    def __init__(self, url, headers=None, append_query_string=False, map_audio=False):
+
+        self.map_audio = map_audio
+        self.append_query_string = append_query_string
+        self.headers = headers
+        self.url = url
+
+        self.media_streams = []  # type: list[MediaStream]
+        self.media_streams_checked = False
+
+    @staticmethod
+    def get_streams(url, headers=None, append_query_string=False, map_audio=False):
+        """ Parsers standard M3U8 lists and returns a list of tuples with streams and bitrates and resolutions that
+        can be used by other methods.
+
+        :param dict[str,str] headers:       Possible HTTP Headers
+        :param str url:                     The url to download
+        :param bool append_query_string:    Should the existing query string be appended?
+        :param bool map_audio:              Map audio streams
+
+        :return: a list of streams with their bitrate and their resolution and optionally the audio streams.
+        :rtype: list[tuple[str,str,str]|tuple[str,str,str,str]]
+
+        """
+
+        streams = []
+        resp = urlquick.get(url, headers=headers, max_age=-1)
+        data = resp.text
+
+        qs = None
+        if append_query_string and "?" in url:
+            base, qs = url.split("?", 1)
+            Script.log("Going to append QS: %s" % qs, lvl=Script.INFO)
+        elif "?" in url:
+            base, qs = url.split("?", 1)
+            Script.log("Ignoring QS: %s" % qs, lvl=Script.INFO)
+            qs = None
+        else:
+            base = url
+
+        Script.log("Processing M3U8 Streams: %s" % url, lvl=Script.DEBUG)
+
+        # If we need audio
+        if map_audio:
+            found_streams = M3u8.PATTERN_AUDIO1.findall(data)
+            found_streams += M3u8.PATTERN_AUDIO2.findall(data)
+        else:
+            found_streams = M3u8.PATTERN_STREAMS.findall(data)
+
+        audio_streams = {}
+        base_url = base[:base.rindex("/")]
+        for found_stream in found_streams:
+            if "#EXT-X-I-FRAME" in found_stream[TYPE_INDEX]:
+                continue
+
+            if "://" not in found_stream[URL_INDEX]:
+                stream = "%s/%s" % (base_url, found_stream[URL_INDEX])
+            else:
+                stream = found_stream[URL_INDEX]
+            bitrate = found_stream[BITRATE_INDEX]
+            if map_audio:
+                resolution = "0x0"
+            else:
+                resolution = found_stream[RESOLUTION_INDEX]
+
+            if qs is not None and stream.endswith("?null="):
+                stream = stream.replace("?null=", "?%s" % (qs,))
+            elif qs is not None and "?" in stream:
+                stream = "%s&%s" % (stream, qs)
+            elif qs is not None:
+                stream = "%s?%s" % (stream, qs)
+
+            if map_audio and "#EXT-X-MEDIA" in found_stream[TYPE_INDEX]:
+                Script.log("Found audio stream: %s -> %s" % (found_stream[ID_INDEX], stream), lvl=Script.DEBUG)
+                audio_streams[found_stream[ID_INDEX]] = stream
+                continue
+
+            if map_audio:
+                streams.append((stream, bitrate, resolution, audio_streams.get(found_stream[ID_INDEX]) or None))
+            else:
+                streams.append((stream, bitrate, resolution))
+
+        Script.log("Found %s substreams in M3U8" % len(streams), lvl=Script.DEBUG)
+        return streams
+
+    @staticmethod
+    def get_media_streams(url, headers=None, append_query_string=False, map_audio=False):
+        media_streams = []
+        if map_audio:
+            for s, b, r, a in M3u8.get_streams(url, headers=headers, append_query_string=append_query_string,
+                                               map_audio=True):
+                if a:
+                    audio_part = a.rsplit("-", 1)[-1]
+                    audio_part = "-%s" % (audio_part,)
+                    s = s.replace(".m3u8", audio_part)
+                media_streams.append(MediaStream(s, b, r))
+
+        for s, b, r in M3u8.get_streams(url, headers=headers, append_query_string=append_query_string, map_audio=False):
+            media_streams.append(MediaStream(s, b, r))
+
+        return media_streams
+
+    def get_matching_stream(self, bitrate):
+        """ Returns the MediaStream for the requested bitrate.
+
+        Arguments:
+        bitrate : integer - The bitrate of the stream in kbps
+
+        Returns:
+        The url of the stream with the requested bitrate.
+
+        If bitrate is not specified the highest bitrate stream will be used.
+
+        """
+
+        if not self.media_streams_checked:
+            self.media_streams = M3u8.get_media_streams(self.url, self.headers, self.append_query_string,
+                                                        self.map_audio)
+            self.media_streams_checked = True
+
+        # order the items by bitrate
+        self.media_streams.sort(key=lambda s: s.bitrate)
+        best_stream = None
+        best_distance = None
+
+        if bitrate == 0:
+            # return the highest one
+            return self.media_streams[-1]
+
+        for stream in self.media_streams:
+            if stream.bitrate is None:
+                # no bitrate set, see if others are available
+                continue
+
+            # this is the bitrate-as-max-limit-method
+            if stream.bitrate > bitrate:
+                # if the bitrate is higher, continue for more
+                continue
+            # if commented ^^ , we get the closest-match-method
+
+            # determine the distance till the bitrate
+            distance = abs(bitrate - stream.bitrate)
+
+            if best_distance is None or best_distance > distance:
+                # this stream is better, so store it.
+                best_distance = distance
+                best_stream = stream
+
+        if best_stream is None:
+            # no match, take the lowest bitrate
+            return self.media_streams[0]
+
+        return best_stream
+
+    def get_url_and_bitrate_for_quality(self):
+        """ Returns the url and the bitrate for the requested quality.
+
+         Returns:
+         The url of the stream and the requested bitrate.
+
+         """
+
+        final_video_url = self.url
+        desired_quality = Script.setting.get_string('quality')
+        if desired_quality == "DEFAULT":
+            return final_video_url, 0
+
+        if not self.media_streams_checked:
+            self.media_streams = M3u8.get_media_streams(self.url, self.headers, self.append_query_string,
+                                                        self.map_audio)
+            self.media_streams_checked = True
+
+        if len(self.media_streams) == 0:
+            return final_video_url, 0
+
+        all_video_resolutions = list(map(lambda x: x.resolution, self.media_streams))
+        all_video_bitrates = list(map(lambda x: x.bitrate, self.media_streams))
+        all_video_qualities = list(map(lambda x: 'resolution: %s, bitrate: %s'
+                                                 % (x.resolution, x.bitrate), self.media_streams))
+        all_videos_urls = list(map(lambda x: x.url, self.media_streams))
+
+        if desired_quality == "DIALOG":
+            selected_item = xbmcgui.Dialog().select(
+                Script.localize(30709),
+                all_video_qualities)
+            if selected_item == -1:
+                return None, None
+
+            return all_videos_urls[selected_item], (all_video_bitrates[selected_item] + BITRATE_OFFSET)
+
+        elif desired_quality == "BEST":
+            max_resolution = 0
+            url_best = self.url
+            i = 0
+            for data_video in all_video_resolutions:
+                current_resolution = int(re.sub(r'x\d*', '', data_video))
+                if current_resolution > max_resolution:
+                    max_resolution = current_resolution
+                    url_best = all_videos_urls[i]
+                i = i + 1
+            return url_best, 0  # you can return bitrate unlimited (0)
+
+        elif desired_quality == "WORST":
+            min_resolution = 99999999999999999999999
+            url_worst = self.url
+            bitrate_worst = 0
+            i = 0
+            for data_video in all_video_resolutions:
+                current_resolution = int(re.sub(r'x\d*', '', data_video))
+                if current_resolution < min_resolution:
+                    min_resolution = current_resolution
+                    url_worst = all_videos_urls[i]
+                    bitrate_worst = all_video_bitrates[i]
+                i = i + 1
+            return url_worst, (bitrate_worst + BITRATE_OFFSET)
+
+        return final_video_url, 0

--- a/resources/lib/streams/mediastream.py
+++ b/resources/lib/streams/mediastream.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, darodi
+# GNU General Public License v2.0+ (see LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt)
+
+# This file is part of Catch-up TV & More
+
+class MediaStream:
+    """Class that represents a Mediastream with <url> and a specific <bitrate> and a specific <resolution>"""
+
+    def __init__(self, url, bitrate=0, resolution="0x0", *args):
+        """Initialises a new MediaStream
+
+        :param str url:                 The URL of the stream.
+        :param int|str bitrate:         The bitrate of the stream (defaults to 0).
+        :param str resolution:          The resolution of the stream (defaults to 0x0).
+        :param tuple[str,str] args:     (name, value) for any stream property.
+
+        """
+
+        self.resolution = resolution
+        self.url = url
+        self.bitrate = int(bitrate)
+
+    def __eq__(self, other):
+        """ Checks 2 items for Equality
+
+        Equality takes into consideration:
+
+        * The url of the MediaStream
+
+        :param MediaStream other:   The stream to check for equality.
+
+        :return: True if the items are equal.
+        :rtype: bool
+
+        """
+
+        # also check for URL
+        if other is None:
+            return False
+
+        return self.url == other.url
+
+    def __str__(self):
+        """ String representation
+
+        :return: The String representation
+        :rtype: str
+
+        """
+        text = "MediaStream: %s [bitrate=%s, resolution=%s]" % (self.url, self.bitrate, self.resolution)
+        return text

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -27,10 +27,11 @@
 
         <!-- Video quality -->
         <setting label="30150" type="lsep" />
-            <setting label="30151" type="labelenum" id="quality" values="BEST|DEFAULT|DIALOG" default="BEST"/>
-            <setting label="30197" type="action" action="Addon.OpenSettings(inputstream.adaptive)" option="close" visible="System.HasAddon(inputstream.adaptive)"/>
-            <setting label="30198" type="bool" id="use_ia_hls_live" default="true"/>
-            <setting label="30199" type="bool" id="use_ytdl_live" default="false"/>
+            <setting label="30151" type="labelenum" id="quality" values="BEST|DEFAULT|DIALOG|WORST" default="BEST"/>
+            <setting id="stream_bitrate_limit" type="select" label="30196" default="0" values="0|100|250|500|750|1000|1500|2000|2500|4000|8000|20000" />
+            <setting label="30198" type="bool" id="use_ia_hls_stream" default="System.HasAddon(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)" />
+            <setting label="30197" type="action" subsetting="true"  action="Addon.OpenSettings(inputstream.adaptive)" option="close" enable="eq(-1,true)"/>
+            <setting label="30199" type="bool" id="use_ytdl_stream" default="false" enable="eq(-2,false)"/>
 
 
         <!-- Content -->
@@ -95,7 +96,7 @@
 
     <!-- Downloads -->
     <category label="30003">
-        <setting label="30012" type="lsep"/>
+        <setting label="30012" type="action" action="Addon.OpenSettings(script.module.youtube.dl)" option="close" enable="System.HasAddon(script.module.youtube.dl)" />
         <setting label="30200" type="folder" id="dl_folder" source="" option="writeable"/>
         <setting label="30201" type="labelenum" id="dl_quality" visible="true" values="SD|720p|1080p|Highest available" default="Highest available"/>
         <setting label="30202" type="bool" id="dl_background" default="false" visible="true"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -96,6 +96,7 @@
 
     <!-- Downloads -->
     <category label="30003">
+        <setting label="30012" type="lsep"/>
         <setting label="30012" type="action" action="Addon.OpenSettings(script.module.youtube.dl)" option="close" enable="System.HasAddon(script.module.youtube.dl)" />
         <setting label="30200" type="folder" id="dl_folder" source="" option="writeable"/>
         <setting label="30201" type="labelenum" id="dl_quality" visible="true" values="SD|720p|1080p|Highest available" default="Highest available"/>


### PR DESCRIPTION
resolver_proxy : get_stream_with_quality

- ajout d'un paramètre: `stream_bitrate_limit`  pour overrider la valeur de limite de bitrate uniquement dans CUTVM sans changer la config de input stream adaptive générale qui peut impacter les autres plugins kodi
- gestion de la `qualité` dans les cas où on désactive input stream adaptive
- utilisation de la valeur de la préférence `qualité` quand on utilise input stream adaptive