### PR TITLE
[FR - L'equipe] Handle correctly multiple stream

### DIFF
--- a/resources/lib/channels/fr/lequipe.py
+++ b/resources/lib/channels/fr/lequipe.py
@@ -9,13 +9,13 @@ from builtins import str
 import json
 import re
 
-from codequick import Listitem, Resolver, Route, Script
+from codequick import Listitem, Resolver, Route
 import urlquick
 
 from resources.lib import resolver_proxy, web_utils
 from resources.lib.menu_utils import item_post_treatment
 
-
+import xbmcgui
 # TO DO
 # Rework Date/AIred
 
@@ -23,14 +23,7 @@ URL_ROOT = 'https://www.lequipe.fr'
 
 URL_LIVE = URL_ROOT + '/lachainelequipe/'
 
-URL_INFO_STREAM_LIVE = URL_ROOT + '/js/app.%s.js'
-
 URL_API_LEQUIPE = URL_ROOT + '/equipehd/applis/filtres/videosfiltres.json'
-
-# TODO Channels 1 and 2 are missing
-ADDITIONAL_LIVES = ['k1kypsRZF9plQhqwBRS', 'k5TgcOKBUTM2KnqwBWC', 'kXRfcKHV9HhcZuqwBYP', 'k6oih7JyuEmhrnqwBZT', 'k3HiS3JB0BsORKqwC49',
-                    'k6P3xLH5tTtGSgqwC4P', 'k1y3Q3GC7w8flQry8S3', 'k5VKYQn5hAE4vfry927', 'k2Z9T8IhyLWvyPtITYJ', 'k53cYSxIs49Vf0wkv86',
-                    'k7rZDp22dyZ25EwkvsF', 'k6c3A07yUljlAzwkvtL']
 
 
 @Route.register
@@ -87,18 +80,33 @@ def list_videos(plugin, item_id, program_url, page, **kwargs):
 
 @Resolver.register
 def get_video_url(plugin, item_id, video_id, download_mode=False, **kwargs):
-
     return resolver_proxy.get_stream_dailymotion(plugin, video_id, download_mode)
 
 
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
+    resp = urlquick.get("https://www.lequipe.fr/directs", headers={'user-agent': web_utils.get_random_ua()}, max_age=-1)
+    live_id = re.compile(r'<article.+?<a href="(.+?)".+?alt="(.+?)"').findall(resp.text)
+    list_url = []
+    list_q = []
 
-    if item_id == 'lequipesup':
-        live = kwargs.get('language', Script.setting["lequipesup.language"])
-        live_id = ADDITIONAL_LIVES[int(re.findall("\d+", live)[0]) - 3]
-    else:
-        resp = urlquick.get(URL_LIVE, headers={'User-Agent': web_utils.get_random_ua()}, max_age=-1)
+    list_url.append(URL_LIVE)
+    list_q.append("Flux Princpal")
+    for a in live_id:
+        list_url.append(a[0])
+        list_q.append(a[1])
+
+    if len(list_url) == 0:
+        return ''
+    if len(list_url) == 1:
+        return list_url[0]
+
+    ret = xbmcgui.Dialog().select("selectionner le programme", list_q)
+    if ret > -1:
+        live_id = list_url[ret]
+    resp = urlquick.get(live_id, headers={'user-agent': web_utils.get_random_ua()}, max_age=-1)
+    if live_id == URL_LIVE:
         live_id = re.compile(r'video-id\=\"(.*?)\"', re.DOTALL).findall(resp.text)[0]
-
+    else:
+        live_id = re.compile(r'"EmbedUrl": "(.+?)",').findall(resp.text)[0].rsplit('/', 1)[-1]
     return resolver_proxy.get_stream_dailymotion(plugin, live_id, False)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -66,7 +66,6 @@
                 <setting label="30158" type="labelenum" id="france3regions.language" values="Alpes|Alsace|Aquitaine|Auvergne|Bourgogne|Bretagne|Centre-Val de Loire|Chapagne-Ardenne|Corse|Côte d'Azur|Franche-Comté|Languedoc-Roussillon|Limousin|Lorraine|Midi-Pyrénées|Nord-Pas-de-Calais|Basse-Normandie|Haute-Normandie|Paris Île-de-France|Pays de la Loire|Picardie|Poitou-Charentes|Provence-Alpes|Rhône-Alpes|Nouvelle-Aquitaine" default="Alpes"/>
                 <setting label="30159" type="labelenum" id="la_1ere.language" values="Guadeloupe|Guyane|Martinique|Mayotte|Nouvelle Calédonie|Polynésie|Réunion|St-Pierre et Miquelon|Wallis et Futuna|Outre-mer" default="Guadeloupe"/>
                 <setting label="30171" type="labelenum" id="BFM_regions.language" values="BFM ALSACE|BFM DICI HAUTE-PROVENCE|BFM Grand Lille|BFM Grand Littoral|BFM Lyon|BFM MARSEILLE PROVENCE|BFM NICE COTE D'AZUR|BFM PARIS ILE-DE-FRANCE|BFM TOULON VAR" default="BFM PARIS ILE-DE-FRANCE"/>
-                <setting label="30174" type="labelenum" id="lequipesup.language" values="Direct 3|Direct 4|Direct 5|Direct 6|Direct 7|Direct 8|Direct 9|Direct 10|Direct 11|Direct 12|Direct 13|Direct 14|Direct 15" default="Direct 3"/>
                 <setting label="30175" type="labelenum" id="equidia-racing.language" values="1|2|3|4|5|6|7|8" default="1"/>
 
             <!-- Spain channels -->


### PR DESCRIPTION
L'équipe streams a lot of sports at the same time.
To do this, they use a large list of Dailymotion streams.

In the previous version, Catchup tv use a setting to let the user choose the stream that he want to watch.
But that not a good way to do this because :
- It's hard to guess which sports are on what channel (it's not said in the website).
- It's not a feature that easy to find.
- The old way use an incomplete list of static ID.

The new way is more simple.
It's a dialog that dynamically display what content is currently on live.
![image](https://user-images.githubusercontent.com/24809312/187026549-d81399b0-6009-4795-886c-d93ccf642327.png)
