### PR TITLE
[UK - CHANNEL4] Add subtitles format (.srt)

### DIFF
--- a/resources/lib/channels/uk/channel4.py
+++ b/resources/lib/channels/uk/channel4.py
@@ -152,8 +152,9 @@ def get_video(plugin, programmeId, assetId, **kwargs):
 
     subtitle_url = ''
     if plugin.setting.get_boolean('active_subtitle'):
+        supported_subtitles_formats = ['srt_009', 'sami_001']
         for field in json_video['subtitlesAssets']:
-            if field['format'] == 'sami_001':
+            if field['format'] in supported_subtitles_formats:
                 subtitle_url = field['url']
                 break
 


### PR DESCRIPTION
Successfully tested on Kodi 19.4.
.smi subtitles were already implemented but are not always present so it makes sense to had more supported formats such as .srt subtitles and and more clever code to add more in the future. 
For example, .webvtt and .vtt subtitles are often present but not supported by Kodi 19.