### PR TITLE
[FR - MYTF1] Fix list of categories (#1257)

### DIFF
--- a/resources/lib/channels/fr/mytf1.py
+++ b/resources/lib/channels/fr/mytf1.py
@@ -163,14 +163,13 @@ def list_categories(plugin, item_id, **kwargs):
     json_parser = urlquick.get(URL_API, params=params, headers=headers, max_age=-1).json()
 
     for json_key in list(json_parser['data'].keys()):
-        if json_parser['data'][json_key]['label']:
-            category_name = json_parser['data'][json_key]['label']
-            category_id = json_parser['data'][json_key]['id']
+        category = json_parser['data'][json_key] or {}
 
+        if category.get('label'):
             item = Listitem()
-            item.label = category_name
+            item.label = category['label']
             item.params['item_id'] = item_id
-            item.params['category_id'] = category_id
+            item.params['category_id'] = category['id']
             item.set_callback(list_programs)
             item_post_treatment(item)
 


### PR DESCRIPTION
Voici une proposition pour corriger la liste des catégories pour les replays de MyTF1.

Il y a une (nouvelle ?) catégorie qui est vide ("event"), ce qui n'était pas attendu et faisait planter le traitement.