### PR TITLE
TF1Plus: 403 when fetching index.mpd

### DIFF
--- a/resources/lib/channels/fr/tf1plus.py
+++ b/resources/lib/channels/fr/tf1plus.py
@@ -435,4 +435,5 @@ def get_live_url(plugin, item_id, **kwargs):
 
     return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url,
                                                   manifest_type="mpd", license_url=license_url,
-                                                  workaround=workaround, headers=license_headers)
+                                                  workaround=workaround, headers=headers_video_stream, 
+                                                  custom_license_headers=license_headers)

--- a/resources/lib/channels/fr/tf1plus.py
+++ b/resources/lib/channels/fr/tf1plus.py
@@ -398,15 +398,15 @@ def get_live_url(plugin, item_id, **kwargs):
     }
     params = {
         'context': 'MYTF1',
-        'pver': '5010000',
+        'pver': '5029000',
         'platform': 'web',
         'device': 'desktop',
         'os': 'windows',
         'osVersion': '10.0',
         'topDomain': 'unknown',
-        'playerVersion': '5.10.0',
+        'playerVersion': '5.29.0',
         'productName': 'mytf1',
-        'productVersion': '2.59.1'
+        'productVersion': '3.37.0'
     }
 
     url_json = URL_VIDEO_STREAM % video_id

--- a/resources/lib/channels/fr/tf1plus.py
+++ b/resources/lib/channels/fr/tf1plus.py
@@ -435,5 +435,5 @@ def get_live_url(plugin, item_id, **kwargs):
 
     return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url,
                                                   manifest_type="mpd", license_url=license_url,
-                                                  workaround=workaround, headers=headers_video_stream, 
+                                                  workaround=workaround, headers=headers_video_stream,
                                                   custom_license_headers=license_headers)

--- a/resources/lib/resolver_proxy.py
+++ b/resources/lib/resolver_proxy.py
@@ -266,7 +266,7 @@ def get_stream_with_quality(plugin,
     if license_url is not None:
 
         if '|' not in license_url:  # add headers only if they are not already in the url
-            if custom_license_headers: # use custom_license_headers only if it is set, else fallback to stream_headers
+            if custom_license_headers:  # use custom_license_headers only if it is set, else fallback to stream_headers
                 license_headers = urlencode(custom_license_headers)
             else:
                 license_headers = stream_headers

--- a/resources/lib/resolver_proxy.py
+++ b/resources/lib/resolver_proxy.py
@@ -179,6 +179,7 @@ def get_stream_with_quality(plugin,
                             video_url,
                             manifest_type="hls",
                             headers=None,
+                            custom_license_headers=None,
                             license_url=None,
                             map_audio=False,
                             append_query_string=False,
@@ -193,7 +194,8 @@ def get_stream_with_quality(plugin,
     :param plugin:                      plugin
     :param str video_url:               The url to download
     :param str manifest_type:           Manifest type
-    :param dict headers:                the headers
+    :param dict headers:                the headers, always used for stream, and license only if custom_license_headers is not set
+    :param dict custom_license_headers: the license headers, used only for the license, leaving 'headers' only for the stream part
     :param str license_url:        licence url
     :param bool append_query_string:    Should the existing query string be appended?
     :param bool map_audio:              Map audio streams
@@ -264,7 +266,7 @@ def get_stream_with_quality(plugin,
     if license_url is not None:
 
         if '|' not in license_url:  # add headers only if they are not already in the url
-            license_url = '%s|%s|R{SSM}|' % (license_url, stream_headers)
+            license_url = '%s|%s|R{SSM}|' % (license_url, urlencode(custom_license_headers) if custom_license_headers else stream_headers) # use custom_license_headers only if it is set, else fallback to stream_headers
         item.property['inputstream.adaptive.license_key'] = license_url
 
     if input_stream_properties is not None:

--- a/resources/lib/resolver_proxy.py
+++ b/resources/lib/resolver_proxy.py
@@ -266,7 +266,11 @@ def get_stream_with_quality(plugin,
     if license_url is not None:
 
         if '|' not in license_url:  # add headers only if they are not already in the url
-            license_url = '%s|%s|R{SSM}|' % (license_url, urlencode(custom_license_headers) if custom_license_headers else stream_headers) # use custom_license_headers only if it is set, else fallback to stream_headers
+            if custom_license_headers: # use custom_license_headers only if it is set, else fallback to stream_headers
+                license_headers = urlencode(custom_license_headers)
+            else:
+                license_headers = stream_headers
+            license_url = '%s|%s|R{SSM}|' % (license_url, license_headers)
         item.property['inputstream.adaptive.license_key'] = license_url
 
     if input_stream_properties is not None:


### PR DESCRIPTION
PR to fix [#1427](https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/issues/1427).
It has been tested successfully on LibreElec 12.0.1 with Kodi 21.1.0:
 - TF1Plus: The live channel is working 
 - A dozen of other FR channels are not impacted (live nor replay)

/!\: IMHO: it could be useful to make the `get_stream_with_quality` method differenciate the headers given to `inputstream.adaptive.stream_headers` (+ `inputstream.adaptive.manifest_headers`) and the headers given to the DRM license requests.
Because such a change should impact almost all already implemented channels, I have added a parameter to the method which emulates to old behavior when it's None, and used as I want when filled.

I'm open to improvments, I'm not really happy with the parameter name nor the "workaround" behavior !

