### PR TITLE
[UK - CHANNEL4] Fix duplicates on Next Page and add Sort By setting

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -311,6 +311,10 @@ msgctxt "#30098"
 msgid "Peruvian channels"
 msgstr ""
 
+msgctxt "#30099"
+msgid "UK channels"
+msgstr ""
+
 # Websites (from 30130 to 30149)
 
 
@@ -439,6 +443,10 @@ msgstr ""
 
 msgctxt "#30182"
 msgid "France 3 Régions: Choose subregion"
+msgstr ""
+
+msgctxt "#30183"
+msgid "Channel4: Programmes: Sort By"
 msgstr ""
 
 msgctxt "#30192"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -311,6 +311,10 @@ msgctxt "#30098"
 msgid "Peruvian channels"
 msgstr "Chaînes péruviennes"
 
+msgctxt "#30099"
+msgid "UK channels"
+msgstr "Chaînes UK"
+
 # Websites (from 30130 to 30149)
 
 
@@ -437,9 +441,13 @@ msgctxt "#30181"
 msgid "Choose version"
 msgstr "Choix de la version"
 
-msgctxt "#3082"
+msgctxt "#30182"
 msgid "France 3 Régions: Choose region"
 msgstr "France 3 Régions : Choix de la sous-région"
+
+msgctxt "#30183"
+msgid "Channel4: Programmes: Sort By"
+msgstr ""
 
 msgctxt "#30192"
 msgid "BEST"

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -303,8 +303,12 @@ msgctxt "#30097"
 msgid "Moroccan channels"
 msgstr ""
 
-msgctxt "#30097"
+msgctxt "#30098"
 msgid "Peruvian channels"
+msgstr ""
+
+msgctxt "#30099"
+msgid "UK channels"
 msgstr ""
 
 # Websites (from 30130 to 30149)
@@ -435,6 +439,10 @@ msgstr ""
 
 msgctxt "#30182"
 msgid "France 3 Régions: Choose subregion"
+msgstr ""
+
+msgctxt "#30183"
+msgid "Channel4: Programmes: Sort By"
 msgstr ""
 
 msgctxt "#30192"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -311,6 +311,10 @@ msgctxt "#30098"
 msgid "Peruvian channels"
 msgstr "Peruaans kanalen"
 
+msgctxt "#30099"
+msgid "UK channels"
+msgstr "UK kanalen"
+
 # Websites (from 30130 to 30149)
 
 
@@ -439,6 +443,10 @@ msgstr ""
 
 msgctxt "#30182"
 msgid "France 3 Régions: Choose subregion"
+msgstr ""
+
+msgctxt "#30183"
+msgid "Channel4: Programmes: Sort By"
 msgstr ""
 
 msgctxt "#30192"

--- a/resources/lib/channels/uk/channel4.py
+++ b/resources/lib/channels/uk/channel4.py
@@ -68,7 +68,7 @@ def list_programs(plugin, url, offset, **kwargs):
     params = {
         'json': 'true',
         'offset': offset,
-        'sort' : Script.setting['uk.channel4.programmes.sort.by']
+        'sort': Script.setting['uk.channel4.programmes.sort.by']
     }
     programs = json.loads(urlquick.get(url, headers=BASIC_HEADERS, params=params, max_age=-1).text)
     programs_number = programs['noOfShows']

--- a/resources/lib/channels/uk/channel4.py
+++ b/resources/lib/channels/uk/channel4.py
@@ -12,7 +12,7 @@ import re
 import json
 from builtins import str
 
-from codequick import Listitem, Resolver, Route
+from codequick import Listitem, Script, Resolver, Route
 import urlquick
 
 from resources.lib.kodi_utils import get_kodi_version, get_selected_item_art, get_selected_item_label, get_selected_item_info, INPUTSTREAM_PROP
@@ -67,7 +67,8 @@ def list_programs(plugin, url, offset, **kwargs):
     """
     params = {
         'json': 'true',
-        'offset': offset
+        'offset': offset,
+        'sort' : Script.setting['uk.channel4.programmes.sort.by']
     }
     programs = json.loads(urlquick.get(url, headers=BASIC_HEADERS, params=params, max_age=-1).text)
     programs_number = programs['noOfShows']
@@ -81,7 +82,7 @@ def list_programs(plugin, url, offset, **kwargs):
         item_post_treatment(item)
         yield item
 
-    nboffset = int(offset) + 15
+    nboffset = int(offset) + len(programs["brands"]["items"])
     if nboffset < programs_number:
         yield Listitem.next_page(url=url, offset=str(nboffset))
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -88,6 +88,10 @@
                 <setting label="30164" type="labelenum" id="icitele.language" values="Vancouver|Regina|Toronto|Edmonton|Rimouski|Québec|Winnipeg|Moncton|Ottawa|Sherbrooke|Trois-Rivières|Montréal" default="Montréal"/>
                 <setting label="30170" type="labelenum" id="cbc.language" values="Ottawa|Montreal|Charlottetown|Fredericton|Halifax|Windsor|Yellowknife|Winnipeg|Regina|Calgary|Edmonton|Vancouver|Toronto|St. John\'s" default="Ottawa"/>
 
+            <!-- UK channels -->
+            <setting label="30099" type="lsep" subsetting="true" visible="eq(1,true)"/>
+                <setting label="30183" type="labelenum" id="uk.channel4.programmes.sort.by" values="popular|az|recently-added" default="popular"/>
+
     </category>
     <!-- Quality and Content -->
 


### PR DESCRIPTION
For your consideration please.

1) Noticed the 'next page' offset was hard coded to a value of 15, and as the Channel4 API returns 60 items per call, each next page contained 45 duplicates.  Better to increment the offset based on how many items were returned.

2) Under Add-on settings, under Quality & Content, added new 'UK channels' section with single new entry for 'Channel4: Programmes: Sort By'.  This was added to allow the user to control the presentation order of programmes under the categories.  The default is Popular, but when you're waiting for a new episode to arrive the 'Recently Added' sort option is much better.  Likewise, when trying to find a particular show the 'AZ' is perfect.

https://www.channel4.com/categories/entertainment?json=true&offset=0&sort=recently-added
https://www.channel4.com/categories/entertainment?json=true&offset=0&sort=az
https://www.channel4.com/categories/entertainment?json=true&offset=0&sort=popular (default)

![image](https://github.com/user-attachments/assets/09dd9679-c317-4775-9acf-e9678837a7bc)
