### PR TITLE
Fix hang kodi stop

### DIFF
--- a/resources/lib/constants.py
+++ b/resources/lib/constants.py
@@ -1,0 +1,1 @@
+LOGGER_ID = 'CATCHUP'

--- a/resources/lib/logger.py
+++ b/resources/lib/logger.py
@@ -1,0 +1,31 @@
+
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, SylvainCecchetto, wwark
+# GNU General Public License v2.0+ (see LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt)
+
+# This file is part of Catch-up TV & More
+
+from kodi_six import xbmc, xbmcaddon
+from .constants import LOGGER_ID
+
+class Logger(object):
+    default_level = xbmc.LOGDEBUG
+
+    def log(self, text, log_level=default_level):
+        log_line = '[%s] %s' % (LOGGER_ID, text)
+        xbmc.log(msg=log_line, level=log_level)
+
+    def debug(self, text):
+        self.log(text, xbmc.LOGDEBUG)
+
+    def info(self, text):
+        self.log(text, xbmc.LOGINFO)
+
+    def notice(self, text):
+        self.log(text, xbmc.LOGNOTICE)
+
+    def warning(self, text):
+        self.log(text, xbmc.LOGWARNING)
+
+    def error(self, text):
+        self.log(text, xbmc.LOGERROR)

--- a/service.py
+++ b/service.py
@@ -9,8 +9,11 @@ import sys
 import ssl
 import xbmcvfs
 import pickle
+import threading
+import logging
 
 from kodi_six import xbmc, xbmcaddon
+from resources.lib.logger import Logger
 
 try:  # Python 3
     from http.server import BaseHTTPRequestHandler
@@ -18,11 +21,12 @@ except ImportError:  # Python 2
     from BaseHTTPServer import BaseHTTPRequestHandler
 
 try:  # Python 3
-    from socketserver import TCPServer
+    from socketserver import ThreadingTCPServer
 except ImportError:  # Python 2
-    from SocketServer import TCPServer
+    from SocketServer import ThreadingTCPServer
 
 addon = xbmcaddon.Addon(id='plugin.video.catchuptvandmore')
+LOG = Logger()
 
 requests.packages.urllib3.disable_warnings()
 try:
@@ -74,19 +78,48 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(licens)
 
 
-address = '127.0.0.1'  # Localhost
-
-port = 5057
-
-server_inst = TCPServer((address, port), SimpleHTTPRequestHandler)
-# The follow line is only for test purpose, you have to implement a way to stop the http service!
-server_inst.serve_forever()
-
-
 def autorun_addon():
     if xbmcaddon.Addon().getSetting("auto_run") == "true":
         xbmc.executebuiltin('RunAddon(plugin.video.catchuptvandmore)')
     return
 
 
-autorun_addon()
+class RunMonitor(xbmc.Monitor):
+    def __init__(self):
+        super(RunMonitor, self).__init__()
+        self.system_aborting = False
+
+    def onAbortRequested(self):
+        LOG.debug('########### onAbortrequested for abort demo')
+
+    def onNotification(self, sender, method, data):
+        if method == 'System.OnQuit' or method == 'System.OnRestart':
+            LOG.debug('######## System Aborting')
+            self.system_aborting = True
+
+
+if __name__ == "__main__":
+    LOG.info("start service")
+    monitor = RunMonitor()
+
+    address = '127.0.0.1'  # Localhost
+
+    port = 5057
+
+    server_inst = ThreadingTCPServer((address, port), SimpleHTTPRequestHandler)
+    server_thread = threading.Thread(target=server_inst.serve_forever)
+    server_thread.start()
+    LOG.info("tcp server started")
+
+    autorun_addon()
+
+    while not monitor.abortRequested() and monitor.system_aborting is False:
+        monitor.waitForAbort(5)
+
+    LOG.info("shutdown server")
+    server_inst.shutdown()
+
+    server_inst.server_close()
+
+    server_thread.join()
+    LOG.info("service ended")


### PR DESCRIPTION
Also fixes deactivating then reactivating the addon errors out with
address already in use.
    
Fix by running the license tcpserver from service.py in a thread to prevent deadlock when
shutting this server down from the main thread as it was running in the
main thread too beforehand.

Closes #1452 