### PR TITLE
[UK - MY5] Fixed replay listings and subtitles

### DIFF
--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -207,16 +207,12 @@ def list_subcategories(plugin, browse_name, offset, **kwargs):
         elif root['filters']['type'] == 'Show':
             ids = root['filters']['ids']
             w_params = {
-                'limit': str(item_number),
+                'limit': len(ids),
                 'offset': '0',
                 'platform': 'my5desktop',
-                'friendly': '1'
+                'friendly': '1',
+                'ids[]': ids
             }
-            for i in range(item_number):
-                try:
-                    w_params.update({'ids[]': ids[i]})
-                except (IndexError, ValueError):
-                    pass
             resp = urlquick.get(URL_SHOWS, headers=GENERIC_HEADERS, params=w_params, max_age=-1)
             root = json.loads(resp.text)
             for watchable in root['shows']:
@@ -233,16 +229,12 @@ def list_subcategories(plugin, browse_name, offset, **kwargs):
         elif root['filters']['type'] == 'Watchable':
             ids = root['filters']['ids']
             w_params = {
-                'limit': str(item_number),
+                'limit': len(ids),
                 'offset': '0',
                 'platform': 'my5desktop',
-                'friendly': '1'
+                'friendly': '1',
+                'ids[]': ids
             }
-            for i in range(item_number):
-                try:
-                    w_params.update({'ids[]': ids[i]})
-                except (IndexError, ValueError):
-                    pass
             resp = urlquick.get(URL_WATCHABLE, headers=GENERIC_HEADERS, params=w_params, max_age=-1)
             root = json.loads(resp.text)
 

--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -345,8 +345,23 @@ def get_video_url(plugin, fname, season_f_name, show_id, standalone, **kwargs):
     iv, data = ivdata(LICFULL_URL, auth)
     video_url, drm_url, sub_url = part2(iv, aesKey, data)
 
+    # Currently (Kodi 21.1), dash embedded subtitles from channel5 are not shown.
+    # However, if the same subtitle url is passed to Kodi separately, it does work.
+    subs_url = None
+    if plugin.setting.get_boolean('active_subtitle'):
+        resp = urlquick.get(video_url, headers=GENERIC_HEADERS, max_age=-1)
+        dash_manifest = resp.text
+        # Find the subtitles 'base url' in the manifest, which is actually the file name, rather than the base.
+        match = re.search(r'<AdaptationSet mimeType="text/vtt"[^>]*>.+?<BaseURL>(.+?)</BaseURL>',
+                          dash_manifest, re.DOTALL)
+        if match:
+            # Construct the full url from the real base and the file name.
+            subs_url = '/'.join((video_url.rsplit('/', maxsplit=1)[0],
+                                 match[1]))
+
     return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url, license_url=drm_url,
-                                                  manifest_type='mpd', headers=lic_headers)
+                                                  manifest_type='mpd', headers=lic_headers,
+                                                  subtitles=subs_url)
 
 
 @Resolver.register


### PR DESCRIPTION
Fixes:
- The issue that various listings showed only a single item, when more were available.
- VOD subtitles were not shown.
  I'm not quite sure what the root cause is. I'll try to investigate further to file an issue at ISA, but I wouldn't be surprised if it woud require proxying the manifest request, subtitle request, or both to get the inline titles working. 
   This fix is much simpler and working now.

I've split the PR in 2 commits to make clear what is what. I'm happy to squash, split PRs, or whatever else you advise.