### PR TITLE
[UK] Fix live TV guides

### DIFF
--- a/resources/lib/skeletons/uk_live.py
+++ b/resources/lib/skeletons/uk_live.py
@@ -22,7 +22,7 @@ menu = {
         'label': 'Blaze',
         'thumb': 'channels/uk/blaze.png',
         'fanart': 'channels/uk/blaze_fanart.jpg',
-        'xmltv_id': '1013.tvguide.co.uk',
+        'xmltv_id': '64.freeview.co.uk',
         'enabled': True,
         'order': 1
     },
@@ -31,7 +31,7 @@ menu = {
         'label': 'Dave',
         'thumb': 'channels/uk/dave.png',
         'fanart': 'channels/uk/dave_fanart.jpg',
-        'xmltv_id': '432.tvguide.co.uk',
+        'xmltv_id': '19.freeview.co.uk',
         'enabled': True,
         'order': 2
     },
@@ -40,7 +40,7 @@ menu = {
         'label': 'Yesterday',
         'thumb': 'channels/uk/yesterday.png',
         'fanart': 'channels/uk/yesterday_fanart.jpg',
-        'xmltv_id': '320.tvguide.co.uk',
+        'xmltv_id': '27.freeview.co.uk',
         'enabled': True,
         'order': 3
     },
@@ -49,7 +49,7 @@ menu = {
         'label': 'Drama',
         'thumb': 'channels/uk/drama.png',
         'fanart': 'channels/uk/drama_fanart.jpg',
-        'xmltv_id': '871.tvguide.co.uk',
+        'xmltv_id': '20.freeview.co.uk',
         'enabled': True,
         'order': 4
     },
@@ -58,7 +58,7 @@ menu = {
         'label': 'Sky News',
         'thumb': 'channels/uk/skynews.png',
         'fanart': 'channels/uk/skynews_fanart.jpg',
-        'xmltv_id': '257.tvguide.co.uk',
+        'xmltv_id': '233.freeview.co.uk',
         'enabled': True,
         'order': 5
     },
@@ -67,7 +67,6 @@ menu = {
         'label': 'STV',
         'thumb': 'channels/uk/stv.png',
         'fanart': 'channels/uk/stv_fanart.jpg',
-        'xmltv_id': '178.tvguide.co.uk',
         'enabled': True,
         'order': 6
     },
@@ -76,6 +75,7 @@ menu = {
         'label': 'Channel4',
         'thumb': 'channels/uk/channel4.png',
         'fanart': 'channels/uk/channel4_fanart.jpg',
+        'xmltv_id': '4.freeview.co.uk',
         'enabled': True,
         'order': 7
     },
@@ -84,6 +84,7 @@ menu = {
         'label': 'E4',
         'thumb': 'channels/uk/E4.png',
         'fanart': 'channels/uk/E4_fanart.jpg',
+        'xmltv_id': '13.freeview.co.uk',
         'enabled': True,
         'order': 8
     },
@@ -92,6 +93,7 @@ menu = {
         'label': 'More4',
         'thumb': 'channels/uk/More4.png',
         'fanart': 'channels/uk/More4_fanart.jpg',
+        'xmltv_id': '18.freeview.co.uk',
         'enabled': True,
         'order': 9
     },
@@ -100,6 +102,7 @@ menu = {
         'label': 'Film4',
         'thumb': 'channels/uk/Film4.png',
         'fanart': 'channels/uk/Film4_fanart.jpg',
+        'xmltv_id': '14.freeview.co.uk',
         'enabled': True,
         'order': 10
     },
@@ -108,6 +111,7 @@ menu = {
         'label': '4seven',
         'thumb': 'channels/uk/4seven.png',
         'fanart': 'channels/uk/4seven_fanart.jpg',
+        'xmltv_id': '49.freeview.co.uk',
         'enabled': True,
         'order': 11
     },
@@ -116,7 +120,6 @@ menu = {
         'label': 'Birmingham Local TV',
         'thumb': 'channels/uk/birminghamlocal.png',
         'fanart': 'channels/uk/birminghamlocal_fanart.jpg',
-        'xmltv_id': '1154.tvguide.co.uk',
         'enabled': True,
         'order': 12
     },
@@ -125,7 +128,6 @@ menu = {
         'label': 'Bristol Local TV',
         'thumb': 'channels/uk/bristollocal.png',
         'fanart': 'channels/uk/bristollocal_fanart.jpg',
-        'xmltv_id': '1157.tvguide.co.uk',
         'enabled': True,
         'order': 13
     },
@@ -134,7 +136,6 @@ menu = {
         'label': 'Cardiff Local TV',
         'thumb': 'channels/uk/cardifflocal.png',
         'fanart': 'channels/uk/cardifflocal_fanart.jpg',
-        'xmltv_id': '1171.tvguide.co.uk',
         'enabled': True,
         'order': 14
     },
@@ -143,7 +144,6 @@ menu = {
         'label': 'Leeds Local TV',
         'thumb': 'channels/uk/leedslocal.png',
         'fanart': 'channels/uk/leedslocal_fanart.jpg',
-        'xmltv_id': '1210.tvguide.co.uk',
         'enabled': True,
         'order': 15
     },
@@ -152,7 +152,6 @@ menu = {
         'label': 'Liverpool Local TV',
         'thumb': 'channels/uk/liverpoollocal.png',
         'fanart': 'channels/uk/liverpoollocal_fanart.jpg',
-        'xmltv_id': '1212.tvguide.co.uk',
         'enabled': True,
         'order': 16
     },
@@ -177,7 +176,6 @@ menu = {
         'label': 'Tyne & Wear Local TV',
         'thumb': 'channels/uk/twlocal.png',
         'fanart': 'channels/uk/twlocal_fanart.jpg',
-        'xmltv_id': '1255.tvguide.co.uk',
         'enabled': True,
         'order': 19
     },
@@ -186,7 +184,7 @@ menu = {
         'label': 'Really',
         'thumb': 'channels/uk/really.png',
         'fanart': 'channels/uk/really_fanart.jpg',
-        'xmltv_id': '422.tvguide.co.uk',
+        'xmltv_id': '17.freeview.co.uk',
         'enabled': False,
         'order': 20
     },
@@ -195,7 +193,7 @@ menu = {
         'label': 'Food Network',
         'thumb': 'channels/uk/foodnetwork.png',
         'fanart': 'channels/uk/foodnetwork_fanart.jpg',
-        'xmltv_id': '596.tvguide.co.uk',
+        'xmltv_id': '43.freeview.co.uk',
         'enabled': False,
         'order': 21
     },
@@ -204,7 +202,7 @@ menu = {
         'label': 'DMAX',
         'thumb': 'channels/uk/dmax.png',
         'fanart': 'channels/uk/dmax_fanart.jpg',
-        'xmltv_id': '454.tvguide.co.uk',
+        'xmltv_id': '39.freeview.co.uk',
         'enabled': False,
         'order': 22
     },
@@ -213,6 +211,7 @@ menu = {
         'label': 'HGTV',
         'thumb': 'channels/uk/hgtv.png',
         'fanart': 'channels/uk/hgtv_fanart.jpg',
+        'xmltv_id': '44.freeview.co.uk',
         'enabled': False,
         'order': 23
     },
@@ -221,7 +220,7 @@ menu = {
         'label': 'Quest',
         'thumb': 'channels/uk/questtv.png',
         'fanart': 'channels/uk/questtv_fanart.jpg',
-        'xmltv_id': '559.tvguide.co.uk',
+        'xmltv_id': '12.freeview.co.uk',
         'enabled': False,
         'order': 24
     },
@@ -230,7 +229,7 @@ menu = {
         'label': 'Quest RED',
         'thumb': 'channels/uk/questred.png',
         'fanart': 'channels/uk/questred_fanart.jpg',
-        'xmltv_id': '1014.tvguide.co.uk',
+        'xmltv_id': '40.freeview.co.uk',
         'enabled': False,
         'order': 24
     },
@@ -239,6 +238,7 @@ menu = {
         'label': 'Channel 5 from My5',
         'thumb': 'channels/uk/five.png',
         'fanart': 'channels/uk/five_fanart.jpg',
+        'xmltv_id': '5.freeview.co.uk',
         'enabled': True,
         'order': 25
     },
@@ -247,6 +247,7 @@ menu = {
         'label': '5 Star from My5',
         'thumb': 'channels/uk/fivestar.png',
         'fanart': 'channels/uk/fivestar_fanart.jpg',
+        'xmltv_id': '32.freeview.co.uk',
         'enabled': True,
         'order': 26
     },
@@ -255,6 +256,7 @@ menu = {
         'label': '5 USA from My5',
         'thumb': 'channels/uk/fiveusa.png',
         'fanart': 'channels/uk/fiveusa_fanart.jpg',
+        'xmltv_id': '21.freeview.co.uk',
         'enabled': True,
         'order': 27
     },
@@ -263,6 +265,7 @@ menu = {
         'label': '5 Action from My5',
         'thumb': 'channels/uk/5action.png',
         'fanart': 'channels/uk/5action_fanart.jpg',
+        'xmltv_id': '33.freeview.co.uk',
         'enabled': True,
         'order': 28
     },
@@ -271,6 +274,7 @@ menu = {
         'label': '5 Select from My5',
         'thumb': 'channels/uk/5select.png',
         'fanart': 'channels/uk/5select_fanart.jpg',
+        'xmltv_id': '46.freeview.co.uk',
         'enabled': True,
         'order': 29
     },


### PR DESCRIPTION
No UK TV guides are currently working.

[PR 29 in xmltv](https://github.com/Catch-up-TV-and-More/xmltv/pull/29) changes the grabber to freeview.

This PR implements this change on the side of CUTVM