### PR TITLE
[Project - UK] Add UK-STV EPG

### DIFF
--- a/resources/lib/skeletons/uk_live.py
+++ b/resources/lib/skeletons/uk_live.py
@@ -67,6 +67,7 @@ menu = {
         'label': 'STV',
         'thumb': 'channels/uk/stv.png',
         'fanart': 'channels/uk/stv_fanart.jpg',
+        'xmltv_id': '103.freeview.co.uk',
         'enabled': True,
         'order': 6
     },


### PR DESCRIPTION
Enable STV EPG.

Depends on a [patch submitted to the xmtv repo](https://github.com/Catch-up-TV-and-More/xmltv/issues/33)