### PR TITLE
[PROJECT] Fix Kodi 'hangs' after error.

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -17,6 +17,8 @@ def main():
     if isinstance(exception, Exception):
         main = importlib.import_module('resources.lib.main')
         main.error_handler(exception)
+        sys = importlib.import_module('sys')
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the issues that after an error in CUTVM Kodi could remain unresponsive for quite a long time, showing the busy wheel in the process. 

This happend only in production - when reuselanguageinvoker is set, and primarily when requesting folder content. Caused by the fact that Kodi is waiting for the plugin to finish sending listitems, but Codequick has caught the error, exits normally with zero status and without calling EndOfDirectory(...), or setResolvedUrl(...)

Currently easy to test with one of UK's local channels, becuase the all fail. e.g:
`Catch-up TV > United Kingdom > UK Local TV > Leeds Local TV`

The fix is to exit with a non-zero status after an exception, by wich the interpreter thread ends and the the addon gets re-loaded. This has the additional advantage that people who have CUTVM open while the addon has been updated, will pick up the new version after an error.

It should, of course, preferably be fixed in codequick, but that's worth another discussion.
