### PR TITLE
[UK - STV] Replay: fix missing shows in categories

### DIFF
--- a/resources/lib/channels/uk/stv.py
+++ b/resources/lib/channels/uk/stv.py
@@ -77,7 +77,8 @@ def list_programs(plugin, item_id, category_guid, **kwargs):
     - Les feux de l'amour
     - ...
     """
-    params = {"category": category_guid}
+    params = {"category": category_guid,
+              "limit": "1000"}
     resp = urlquick.get(URL_PROGRAMS_JSON, params=params, headers=GENERIC_HEADERS, max_age=-1)
     json_parser = json.loads(resp.text)
 


### PR DESCRIPTION
Now all shows of a category are listen, instead of just the first 75 shows.

Fixes #1579