### PR TITLE
[UK STV+1] Add EPG

### DIFF
--- a/resources/lib/skeletons/uk_live.py
+++ b/resources/lib/skeletons/uk_live.py
@@ -75,6 +75,7 @@ menu = {
         'resolver': '/resources/lib/channels/uk/stv:get_live_url',
         'label': 'STV +1',
         'thumb': 'channels/uk/stv_plusone.png',
+        'xmltv_id': '35.freeview.co.uk',
         'enabled': True,
         'order': 7
     },


### PR DESCRIPTION
EPG for the recently added live channel STV +1
Depends on the patch in [#35 in xmltv](https://github.com/Catch-up-TV-and-More/xmltv/issues/35)