### PR TITLE
[PROJECT] epg in live listing

### DIFF
--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -153,8 +153,9 @@ def tv_guide_menu(plugin, item_id, **kwargs):
             now_playing = guide_infos[0]
 
             # Title
-            if 'title' in now_playing:
-                item.label = item.label + ' — ' + now_playing['title']
+            show_title = now_playing.get('title')
+            if show_title:
+                item.info['title'] = f'{item.label}    [COLOR orange]{show_title}[/COLOR]'
 
             # Credits
             credits = []

--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -137,7 +137,11 @@ def tv_guide_menu(plugin, item_id, **kwargs):
 
     # Get tv_guide of this country
     xmltv = importlib.import_module('resources.lib.xmltv')
-    tv_guide = xmltv.grab_current_programmes(live_country_id)
+    # Use local time format without seconds. Fix weird kodi formatting for 12-hour clock.
+    time_format = xbmc.getRegion('time').replace(':%S', '').replace('%I%I:', '%I:')
+    tv_guide = xmltv.grab_current_programmes(live_country_id,
+                                             time_range=6,
+                                             time_format=time_format)
 
     # Treat this menu as a generic menu and add, if any, tv guide information
     for item in generic_menu(plugin, live_country_id):
@@ -146,50 +150,31 @@ def tv_guide_menu(plugin, item_id, **kwargs):
         if 'xmltv_id' in item.params and item.params['xmltv_id'] in tv_guide:
             guide_infos = tv_guide[item.params['xmltv_id']]
 
+            now_playing = guide_infos[0]
+
             # Title
-            if 'title' in guide_infos:
-                item.label = item.label + ' — ' + guide_infos['title']
+            if 'title' in now_playing:
+                item.label = item.label + ' — ' + now_playing['title']
 
             # Credits
             credits = []
-            for credit, l in guide_infos.get('credits', {}).items():
+            for credit, l in now_playing.get('credits', {}).items():
                 for s in l:
                     credits.append(s)
             item.info['credits'] = credits
 
-            # Country
-            if 'country' in guide_infos:
-                item.info['country'] = guide_infos['country']
-
-            # Category
-            if 'category' in guide_infos:
-                item.info['genre'] = guide_infos['category']
-
-            # Plot
-            plot = []
-
-            # start_time and stop_time must be a string
-            if 'start' in guide_infos and 'stop' in guide_infos:
-                s = guide_infos['start'] + ' - ' + guide_infos['stop']
-                plot.append(s)
-            elif 'stop' in guide_infos:
-                plot.append(guide_infos['stop'])
-
-            if 'sub-title' in guide_infos:
-                plot.append(guide_infos['sub-title'])
-
-            if 'desc' in guide_infos:
-                plot.append(guide_infos['desc'])
-
-            item.info['plot'] = '\n'.join(plot)
-
-            # Duration
-            item.info["duration"] = guide_infos.get('length')
+            item.info['country'] = now_playing.get('country')
+            item.info['genre'] = now_playing.get('category')
+            item.info["duration"] = now_playing.get('length')
 
             # Art
             if 'icon' in guide_infos:
-                item.art["clearlogo"] = item.art["thumb"]
-                item.art["thumb"] = guide_infos['icon']
+                item.art["clearlogo"] = now_playing.art["thumb"]
+                item.art["thumb"] = now_playing['icon']
+
+            # Build plot from EPG of upcoming programmes, with a max of 12 programmes.
+            plot = '\n'.join(f"{pgm.get('start', '')} - {pgm.get('title', '')}" for pgm in guide_infos[:12])
+            item.info['plot'] = plot
 
         # Playcount is useless for live streams
         item.info['playcount'] = 0

--- a/resources/lib/xmltv.py
+++ b/resources/lib/xmltv.py
@@ -255,53 +255,14 @@ def elem_to_programme(elem):
     return d
 
 
-def read_programmes(fp, only_current_programmes=False):
+def read_programmes(fp):
     """
     read_current_programmes(fp) -> list
 
     Return a list of programme dictionaries from file object 'fp'
-    If 'only_current_programmes', only considere current program based on current time.
+
     """
-
-    if only_current_programmes:
-        # Get the current UTC datetime
-        current_utc_time = datetime.datetime.now(pytz.UTC)
-        current_utc_time = int(current_utc_time.strftime(date_format_notz))
-
-        # Parse the xmltv file to only keep current programs
-        # It is faster to parse the xmltv file line by line and remove unwanted programmes
-        # than parsing the whole xmltv file with elementtree
-        # (x10 faster)
-        xmltv_l = []
-        with open(fp, 'rb') as f:
-            take_line = True
-            for line in f:
-                # Match the beginning of a program
-                if b'<programme ' in line:
-                    start = int(re.search(b'start="(.*?)"', line).group(1))  # UTC start time
-                    try:
-                        stop = int(re.search(b'stop="(.*?)"', line).group(1))  # UTC stop time
-                    except Exception:
-                        stop = 50000000000000
-                    if current_utc_time >= start and current_utc_time <= stop:
-                        pass
-                    else:
-                        take_line = False
-                        continue
-
-                # Keep this line if needed
-                if take_line:
-                    xmltv_l.append(line)
-
-                # Match the end of a program
-                if b'</programme>' in line:
-                    take_line = True
-
-        # Parse the reduced xmltv string with elementtree
-        # and convert each programme to a dict
-        tree = ET.fromstring(b''.join(xmltv_l))
-    else:
-        tree = ET.parse(fp)
+    tree = ET.parse(fp)
     programmes = []
     for elem in tree.findall('programme'):
         programmes.append(elem_to_programme(elem))
@@ -311,7 +272,67 @@ def read_programmes(fp, only_current_programmes=False):
 # CUTV&M functions
 
 
-def programme_post_treatment(programme):
+def read_current_programmes(fp, time_range=0):
+    """ Read an xmltv file and return a list of programme dictionaries
+    of all programmes from now up to a number of hours in the future
+    defined by the parameter `time_range`.
+    If `time-range` == 0, only the programmes currently on are returned.
+
+    Args:
+        fp (str): file path of the xmltv file
+        time_range (float): number of hours
+    Returns:
+        list: list of dicts of programmes info.
+    """
+
+    # Get the current UTC datetime
+    range_start = datetime.datetime.now(pytz.UTC)
+    range_end = range_start + datetime.timedelta(hours=time_range)
+    range_start = int(range_start.strftime(date_format_notz))
+    range_end = int(range_end.strftime(date_format_notz))
+
+    # Parse the xmltv file to only keep current programs
+    # It is faster to parse the xmltv file line by line and remove unwanted programmes
+    # than parsing the whole xmltv file with elementtree
+    # (x10 faster)
+    start_regex = re.compile(b'start="(.*?)"', re.DOTALL)
+    stop_regex = re.compile(b'stop="(.*?)"', re.DOTALL)
+    xmltv_l = []
+    with open(fp, 'rb') as f:
+        take_line = True
+        for line in f:
+            # Match the beginning of a program
+            if b'<programme ' in line:
+                start = int(start_regex.search(line).group(1))  # UTC start time
+                try:
+                    stop = int(stop_regex.search(line).group(1))  # UTC stop time
+                except Exception:
+                    stop = 50000000000000
+                if start < range_end and stop >= range_start:
+                    pass
+                else:
+                    take_line = False
+                    continue
+
+            # Keep this line if needed
+            if take_line:
+                xmltv_l.append(line)
+
+            # Match the end of a program
+            if b'</programme>' in line:
+                take_line = True
+
+    # Parse the reduced xmltv string with elementtree
+    # and convert each programme to a dict
+    tree = ET.fromstring(b''.join(xmltv_l))
+
+    programmes = []
+    for elem in tree.findall('programme'):
+        programmes.append(elem_to_programme(elem))
+    return programmes
+
+
+def programme_post_treatment(programme, timeformat):
     """Prepare the programme to be used in the Live TV menu of CUTV&M
 
     """
@@ -361,7 +382,7 @@ def programme_post_treatment(programme):
             # Move to our timezone
             elt_dt = elt_dt.astimezone(local_tz)
 
-            programme[elt] = elt_dt.strftime("%Hh%M")
+            programme[elt] = elt_dt.strftime(timeformat)
 
     return programme
 
@@ -654,7 +675,7 @@ def grab_programmes(country_id, day_delta):
         xmltv_fp = get_xmltv_filepath(country_id, day_delta=day_delta)
 
         # Grab programmes in xmltv file
-        programmes = read_programmes(xmltv_fp, only_current_programmes=False)
+        programmes = read_programmes(xmltv_fp)
         programmes_post_treated = []
         for programme in programmes:
             programmes_post_treated.append(programme_post_treatment_iptvmanager(programme))
@@ -665,29 +686,46 @@ def grab_programmes(country_id, day_delta):
         return []
 
 
-def grab_current_programmes(country_id):
+def grab_current_programmes(country_id, time_range=0, time_format='%Hh%M'):
     """Retrieve current programmes of channels of country_id.
+
+    Return for each tv channels a list of programmes in a time period
+    from now up to `time_range` number of hours in the future.
+    If time_range is 0 only the current programmes will be returned.
 
     Args:
         country_id (str)
+        time_range (float)
+        time_format (str)
     Returns:
-        dict: (key: xmltv_id, value: current programme)
+        dict: (key: xmltv_id, value: list of current programmes)
     """
     if country_id not in xmltv_infos:
         return {}
     try:
-        # Download, if needed, xmltv file of today
-        xmltv_fp = get_xmltv_filepath(country_id)
-
+        # Download, if needed, xmltv file of today and possibly the next day
         # Grab current programmes in xmltv file
-        programmes = read_programmes(xmltv_fp, only_current_programmes=True)
+        xmltv_fp = get_xmltv_filepath(country_id)
+        programmes = read_current_programmes(xmltv_fp, time_range=time_range)
+
+        now = datetime.datetime.now(tz=pytz.UTC)
+        if now.hour + time_range > 24:
+            xmltv_fp = get_xmltv_filepath(country_id, 1)
+            programmes.extend(read_current_programmes(xmltv_fp, time_range=time_range))
+        if not programmes:
+            return {}
 
         # Use the channel as key
         tv_guide = {}
         for programme in programmes:
-            programme = programme_post_treatment(programme)
-            tv_guide[programme['channel']] = programme
-
+            chan_id = programme['channel']
+            pgm_list = tv_guide.setdefault(chan_id, [])
+            formatted_pgm = programme_post_treatment(programme, time_format)
+            # The last programme in the EPG of one day can be the same as the first of the next day.
+            # Check the start time to prevent duplicates.
+            previous_start = pgm_list[-1].get('start') if pgm_list else None
+            if formatted_pgm.get('start') != previous_start:
+                pgm_list.append(formatted_pgm)
         return tv_guide
     except Exception as e:
         Script.notify(


### PR DESCRIPTION
This PR is proposition to present listings of live channels in a similar manner as currently used by addons like iplayer www and viwx.

1.  In a live channels description, present a short EPG of the upcoming programmes of the next 6 hours (with a max of 12 programmes), with the start times in the user's local time format
2. In a live channel's listitem, display the programme title in a differtent colour, which I feel, will visually separate the channel name and program name more clearly.

Has of course only effect when the user has enabled 'Enable TV guide (slower)' in settings.