### PR TITLE
[UK - MY5] Replay: user account integration

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -598,6 +598,14 @@ msgctxt "#30265"
 msgid "Channel 4 Password"
 msgstr ""
 
+msgctxt "#30266"
+msgid "Log in to Channel5"
+msgstr ""
+
+msgctxt "#30267"
+msgid "Log out of Channel5"
+msgstr ""
+
 
 # TV integration (from 30270 to 30289)
 
@@ -991,6 +999,22 @@ msgstr ""
 
 msgctxt "#30732"
 msgid "This content requires a payment. To buy or rent it, go to %s website at this URL : %s"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Enter email"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Enter password"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Logged in successfully"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Logged out successfully"
 msgstr ""
 
 

--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -13,7 +13,7 @@ import time
 
 import xbmcplugin
 
-from codequick import Listitem, Resolver, Route
+from codequick import Listitem, Resolver, Route, Script, utils
 
 try:
     import urllib.parse
@@ -46,6 +46,14 @@ ONEOFF = CORONA_URL + 'shows/%s/episodes/next.json'
 LIC_BASE = 'https://cassie.channel5.com/api/v2'
 LICC_URL = LIC_BASE + '/%s/my5desktopng/%s.json?timestamp=%s'
 KEYURL = "https://player.akamaized.net/html5player/core/html5-c5-player.js"
+
+TXT_ENTER_UNAME = 30733
+TXT_ENTER_PASSW = 30734
+TXT_LOGIN_SUCCESS = 30735
+TXT_LOGOUT_SUCCESS = 30736
+TXT_INFORMATION = 30600
+TXT_ACCOUNT_REQUIRED = 30604
+PUBLIC_SITE = 'www.channel5.com'
 
 # Connect and receive timeouts for HTTP requests.
 REQ_TIMEOUT = (3.5, 7)
@@ -515,3 +523,163 @@ def availability(end_time):
         hours_available = int(t_available / 3600)
         return '[COLOR orange]Only {} hour{} available.[/COLOR]'.format(
             hours_available, 's' if hours_available != 1 else '')
+
+
+# -----------------------------------------------------------------------------
+#           CHANNEL 5 ACCOUNT
+# -----------------------------------------------------------------------------
+
+
+def get_session_token(msg_on_fail=True):
+    """Return the locally stored session token, which is needed to request user-related
+    data from channel5.
+
+    Args:
+        msg_on_fail (bool):
+            When `True` the user is asked to sign in when no token is available.
+            When False the function fails silently.
+    Returns:
+        str
+    """
+    sess_token = Script.setting.get_string('uk.chan5.session-token')
+    if sess_token:
+        return sess_token
+    else:
+        Script.log("[UK-Chan5] No session token in settings, user has to log in")
+        if not msg_on_fail:
+            return None
+        import xbmcgui
+        xbmcgui.Dialog().ok(
+            Script.localize(TXT_INFORMATION),
+            Script.localize(TXT_ACCOUNT_REQUIRED) % ('Channel5 (UK)', ('%s' % PUBLIC_SITE)))
+        return None
+
+
+def enter_credentials(uname, passw):
+    """Open the keyboard and ask the user to enter his username and password."""
+    new_username = utils.keyboard(Script.localize(TXT_ENTER_UNAME), uname or '')
+    if new_username:
+        new_passw = utils.keyboard(Script.localize(TXT_ENTER_PASSW), passw or '', hidden=True)
+    else:
+        new_passw = ''
+    return new_username, new_passw
+
+
+def aws_authenticate(req_data):
+    """Perform an authentication request and return a dict of tokens.
+
+    Depending on req_data, does either a new log in with a username and password,
+    or a token refresh.
+
+    """
+    try:
+        headers = {
+            "User-Agent": web_utils.get_random_ua(),
+            'x-amz-target': 'AWSCognitoIdentityProviderService.InitiateAuth',
+            'content-type': 'application/x-amz-json-1.1',
+            'cache-control': 'max-age=0'
+        }
+        # Post credentials
+        resp = urlquick.post(
+            'https://cognito-idp.eu-west-2.amazonaws.com',
+            headers=headers,
+            json=req_data,
+            timeout=REQ_TIMEOUT,
+            max_age=-1
+        )
+        resp.raise_for_status()
+        data = json.loads(resp.content)
+        return data['AuthenticationResult']
+    except urlquick.HTTPError as e:
+        Script.log("[UK-Chan5] Failed to authenticate: %r - %s",
+                   (e, e.response.content), lvl=Script.ERROR)
+        try:
+            resp_data = e.response.json()
+            msg = resp_data.get('message') or resp_data['__type']
+            Script.log("[UK-Chan5] Authentication error msg '%s' from error data '%s'",
+                       (msg, resp_data), Script.ERROR)
+        except Exception as err:
+            Script.log("[UK-Chan5] Failed to parse error: %r",
+                       (err, ), Script.ERROR)
+            raise e
+        raise urlquick.HTTPError(msg)
+
+
+def request_session_token(id_token):
+    """Request a session token from channel5.
+    This token is needed to request authenticated data from channel5.
+
+    """
+    headers = GENERIC_HEADERS
+    resp = urlquick.post(
+        'https://userservice-api.channel5.com/user/validateCognitoToken',
+        headers=headers,
+        json={'cognitoIdToken': id_token},
+        timeout=REQ_TIMEOUT,
+        max_age=-1
+    )
+    resp.raise_for_status()
+    data = json.loads(resp.content)
+    sess_token = data['sessionToken']
+    return sess_token
+
+
+def perform_signin_request(uname, passw):
+    """Sign in to a Channel5 account with `uname` and `passw`.
+
+    First obtain a set of tokens from AWS and then use the IdToken to
+    get a session token from channel5.
+
+    """
+    Script.log("[UK-Chan5] Trying to sign in to account", lvl=Script.INFO)
+    req_data = {
+        "AuthFlow": "USER_PASSWORD_AUTH",
+        "ClientId": "10ap8l6jp0vhreaac79c3qr1lq",
+        "AuthParameters": {"USERNAME": uname, "PASSWORD": passw},
+        "ClientMetadata": {}
+    }
+
+    auth_result = aws_authenticate(req_data)
+    sess_token = request_session_token(auth_result['IdToken'])
+    # Store the session token for later use.
+    Script.setting['uk.chan5.session-token'] = sess_token
+    Script.log("[UK-Chan5] Sign in successful.", lvl=Script.INFO)
+    return True
+
+
+@Script.register
+def sign_in_account(addon):
+    """Entry point for the action 'Log in to channel5 account' in settings.
+
+    Ask the user to enter his username and password, try to log in and inform the
+    user of success or failure. On failure, keep asking for username or password
+    until log in succeeds, or the user cancels the keyboard.
+
+    """
+    import xbmcgui
+    import xbmc
+
+    uname = None
+    passw = None
+
+    while True:
+        uname, passw = enter_credentials(uname, passw)
+        if not all((uname, passw)):
+            addon.log("[UK-Chan5] Login canceled by user", lvl=Script.INFO)
+            return
+        try:
+            perform_signin_request(uname, passw)
+            xbmcgui.Dialog().ok('Channel5', Script.localize(TXT_LOGIN_SUCCESS))
+            xbmc.executebuiltin('Container.Refresh')
+            return
+        except urlquick.HTTPError as e:
+            addon.notify("Error", str(e), display_time=7000)
+
+
+@Script.register
+def sign_out_account(_):
+    """Entry point for the action 'Log out from channel5 account' in settings."""
+    import xbmcgui
+
+    Script.setting['uk.chan5.session-token'] = ''
+    xbmcgui.Dialog().ok('Channel5', Script.localize(TXT_LOGOUT_SUCCESS))

--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -11,6 +11,7 @@ import base64
 import urlquick
 import time
 
+import xbmc
 import xbmcplugin
 
 from codequick import Listitem, Resolver, Route, Script, utils
@@ -77,6 +78,16 @@ lic_headers = {
     'Referer': 'https://www.channel5.com/',
     'Content-Type': '',
 }
+
+
+# A cached list of show ID's currently on channel 5's MyList
+# Possible value types:
+#   None: uninitialised
+#   False: initialised, but unavailable (user is not signed in)
+#   List: intialised with current shows obtained from channel 5 (could still be an empty list)
+# Note:
+#   This only works well in production where 'reuselanguageinvoker' is enabled.
+my_list_ids = None
 
 
 def getdata(ui, media):
@@ -152,6 +163,10 @@ def part2(iv, aesKey, rdata):
 
 @Route.register(autosort=False, content_type="videos")
 def list_main_page(plugin, **kwargs):
+    yield Listitem.from_dict(
+        list_submenu_my5,
+        'My 5'
+    )
     yield from list_hero_items(plugin)
     yield Listitem.from_dict(
         callback=list_collections,
@@ -171,6 +186,29 @@ def list_hero_items(plugin):
         title = li.label
         li.info['title'] = f'[B][COLOR orange]{title}[/COLOR][/B]'
         yield li
+
+
+@Route.register(autosort=False, content_type="videos")
+def list_submenu_my5(plugin, **kwargs):
+    """List collections for which a user account is required."""
+    yield Listitem.from_dict(
+        list_my_list_shows,
+        'My List'
+    )
+
+
+@Route.register
+def list_my_list_shows(plugin, **_):
+    """List all items currently on channel5's MyList."""
+    my_shows = request_user_collection('mylist', show_login_msg=True)
+    if not my_shows:
+        yield False
+        return
+    # Update the cached list of ID's
+    global my_list_ids
+    my_list_ids = [s['id'] for s in my_shows]
+    for show in my_shows:
+        yield parse_show(show)
 
 
 @Route.register
@@ -280,35 +318,50 @@ def search_shows(plugin, params, offset=0):
     data = json.loads(resp.text)
 
     for emission in data['shows']:
-        title = emission['title']
-        fname = emission['f_name']
-        show_id = emission['id']
+        yield parse_show(emission)
 
-        item = Listitem()
-        item.label = title
-        item.art['thumb'] = item.art['landscape'] = SHOW_IMG_URL % show_id
-        item.info['plot'] = emission['s_desc']
-        item.info['genre'] = emission['genre']
-        if "standalone" in emission:
-            # The item is playable
-            item.set_callback(get_video_url,
-                              fname=fname,
-                              season_f_name="",
-                              show_id='',
-                              standalone="yes")
-        else:
-            item.set_callback(list_seasons,
-                              fname=fname,
-                              pid=show_id,
-                              title=title)
-        item_post_treatment(item)
-        yield item
     if 'next_page_url' in data:
         item = Listitem.next_page(callback=search_shows,
                                   params=params,
                                   offset=data['next_offset'])
         item.property['SpecialSort'] = 'bottom'
         yield item
+
+
+def parse_show(show_data):
+    """Parse a dictionary with data of one show and return a
+    Codequick Listitem
+
+    Args:
+        show_data (dict)
+    Returns:
+        Listitem: codequick listitem
+
+    """
+    title = show_data['title']
+    fname = show_data['f_name']
+    show_id = show_data['id']
+
+    item = Listitem()
+    item.label = title
+    item.art['thumb'] = item.art['landscape'] = SHOW_IMG_URL % show_id
+    item.info['plot'] = show_data['s_desc']
+    item.info['genre'] = show_data['genre']
+    if "standalone" in show_data:
+        # The item is playable
+        item.set_callback(get_video_url,
+                          fname=fname,
+                          season_f_name="",
+                          show_id='',
+                          standalone="yes")
+    else:
+        item.set_callback(list_seasons,
+                          fname=fname,
+                          pid=show_id,
+                          title=title)
+    mylist_ctx_mnu(item, show_id, fname)
+    item_post_treatment(item)
+    return item
 
 
 @Route.register(content_type="videos")
@@ -349,6 +402,7 @@ def list_seasons(plugin, fname, pid, title, **kwargs):
         item.label = ' '.join((title, '- Season', season_number))
         item.art['thumb'] = item.art['landscape'] = SHOW_IMG_URL % pid
         item.set_callback(list_episodes, fname=fname, season_number=season_number)
+        mylist_ctx_mnu(item, pid, fname)
         item_post_treatment(item)
         yield item
 
@@ -429,6 +483,7 @@ def parse_watchable(watchable, from_episode_list=False):
                       season_f_name=watchable.get('sea_f_name', ''),
                       show_id=watchable_id,
                       standalone="no")
+    mylist_ctx_mnu(item, watchable['sh_id'], show_title)
     item_post_treatment(item)
     return item
 
@@ -437,6 +492,136 @@ def parse_watchable(watchable, from_episode_list=False):
 def do_search(plugin, search_query, **_):
     yield from search_shows(plugin, {'query': search_query, 'limit': '20'})
 
+
+def request_user_collection(collection_name, show_login_msg=True):
+    """Perform an authenticated request to get a collection of user-specific shows.
+
+    Provides content for 'MyList' and other account related lists.
+
+    Args:
+        collection_name (str):
+            The name of the collection to fetch
+        show_login_msg (bool):
+            Whether to ask the user to log in when he's not yet signed in.
+    Returns:
+        list:
+            A list of dicts. Depending on the type of collection the dicts contain
+            either show data, or watchables.
+
+    """
+    session_tkn = get_session_token(show_login_msg)
+    if not session_tkn:
+        return []
+
+    try:
+        resp = urlquick.get('https://corona.channel5.com/collections/%s.json' % collection_name,
+                            headers={'User-Agent': web_utils.get_random_ua(),
+                                     'Authorization': 'Bearer ' + session_tkn,
+                                     'Pragma': 'no-cache',
+                                     'Cache-Control': 'no-cache'
+                                     },
+                            params={'platform': 'my5desktop', 'friendly': 'true',
+                                    'milkshake': 'include', 'limit': 256},
+                            timeout=REQ_TIMEOUT,
+                            max_age=-1)
+        shows = json.loads(resp.content)['content']
+        return shows
+    except urlquick.HTTPError as err:
+        # Normal response when a list is empty.
+        if err.response.status_code == 404:
+            return []
+        else:
+            raise
+
+
+# -----------------------------------------------------------------------------
+#           CHANNEL 5's MyList
+# -----------------------------------------------------------------------------
+
+def get_my_list():
+    """Request a list of IDs of shows currently on channel 5's MyList and
+    save it in a module level variable for further use during the lifetime
+    of the add-on.
+
+    """
+    global my_list_ids
+    my_shows = request_user_collection('mylist', show_login_msg=False)
+    my_list_ids = [s['id'] for s in my_shows]
+
+
+def mylist_ctx_mnu(list_item, show_id, show_title, retry=True):
+    """Add a context menu item to ``listitem`` to add or removed the item
+    to channel 5's MyList, depending on whether it is already on the list.
+
+    .. Note ::
+
+        This works best in production where reuselanguageinvoker is enabled
+        and the global variable ``my_list_ids`` keeps its value until another
+        addon is opened. During development, each time a folder is opened the
+        list must be requested from the web, which slows things down a bit.
+    """
+    try:
+        if show_id in my_list_ids:
+            list_item.context.script(edit_mylist,
+                                     "Remove from 5's MyList",
+                                     operation='remove',
+                                     show_id=show_id, )
+        else:
+            list_item.context.script(edit_mylist,
+                                     "Add to 5's MyList",
+                                     operation='add',
+                                     show_id=show_id,
+                                     show_title=show_title)
+    except TypeError:
+        if retry and my_list_ids is None:
+            # The cache has not been initialised yet. Get the list and try again.
+            get_my_list()
+            mylist_ctx_mnu(list_item, show_id, show_title, retry=False)
+
+
+@Script.register
+def edit_mylist(plugin, operation, show_id, show_title=None):
+    """Add or remove an item from channel 5's 'MyList'.
+
+    Entry point for the context menu 'Add to/Remove from 5's MyList', present
+    on shows and watchable items.
+    """
+    session_tkn = get_session_token(True)
+    if not session_tkn:
+        return
+
+    if operation == 'add':
+        method = 'put'
+        body = {
+            'platform': 'My5 Web',
+            'showTitle': show_title
+        }
+    elif operation == 'remove':
+        method = 'delete'
+        body = None
+    else:
+        msg = f"Parameter 'operation' must be either 'add' or 'remove', not '{operation}'."
+        plugin.log("[UK - Chan5] Error edit_my_list: " + msg, plugin.ERROR)
+        raise ValueError(msg)
+
+    resp = urlquick.request(
+        method=method,
+        url='https://userservice-api.channel5.com/favourites/' + show_id,
+        headers={'User-Agent': web_utils.get_random_ua(),
+                 'Authorization': 'Bearer ' + session_tkn,
+                 'Pragma': 'no-cache',
+                 'Cache-Control': 'no-cache'},
+        json=body,
+        timeout=REQ_TIMEOUT,
+        max_age=-1)
+    if 200 <= resp.status_code < 300:
+        get_my_list()
+        xbmc.executebuiltin('Container.Refresh')
+
+
+# -----------------------------------------------------------------------------
+#           Resolvers
+# -----------------------------------------------------------------------------
 
 @Resolver.register
 def get_video_url(plugin, fname, season_f_name, show_id, standalone, **kwargs):
@@ -495,6 +680,11 @@ def get_live_url(plugin, item_id, **kwargs):
 
     return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url, license_url=drm_url,
                                                   manifest_type='mpd', headers=lic_headers)
+
+
+# -----------------------------------------------------------------------------
+#           Utilities
+# -----------------------------------------------------------------------------
 
 
 def availability(end_time):
@@ -669,6 +859,8 @@ def sign_in_account(addon):
             return
         try:
             perform_signin_request(uname, passw)
+            global my_list_ids
+            my_list_ids = None
             xbmcgui.Dialog().ok('Channel5', Script.localize(TXT_LOGIN_SUCCESS))
             xbmc.executebuiltin('Container.Refresh')
             return
@@ -681,5 +873,7 @@ def sign_out_account(_):
     """Entry point for the action 'Log out from channel5 account' in settings."""
     import xbmcgui
 
+    global my_list_ids
+    my_list_ids = False
     Script.setting['uk.chan5.session-token'] = ''
     xbmcgui.Dialog().ok('Channel5', Script.localize(TXT_LOGOUT_SUCCESS))

--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -195,6 +195,10 @@ def list_submenu_my5(plugin, **kwargs):
         list_my_list_shows,
         'My List'
     )
+    yield Listitem.from_dict(
+        list_recommendations,
+        "We think you'll like..."
+    )
 
 
 @Route.register
@@ -207,6 +211,17 @@ def list_my_list_shows(plugin, **_):
     # Update the cached list of ID's
     global my_list_ids
     my_list_ids = [s['id'] for s in my_shows]
+    for show in my_shows:
+        yield parse_show(show)
+
+
+@Route.register
+def list_recommendations(plugin, **_):
+    """List recommendations based on previously watched video's."""
+    my_shows = request_user_collection('recommendations', show_login_msg=True)
+    if not my_shows:
+        yield False
+        return
     for show in my_shows:
         yield parse_show(show)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -148,6 +148,10 @@
             <setting label="30264" type="text" id="uk.channel4.login" default=""/>
             <setting label="30265" type="text" id="uk.channel4.password" option="hidden" default=""/>
 
+            <setting label="30266" type="action" action="RunPlugin(plugin://$ID/resources/lib/channels/uk/my5/sign_in_account)" option="close"/>
+            <setting label="30267" type="action" action="RunPlugin(plugin://$ID/resources/lib/channels/uk/my5/sign_out_account)" option="close"/>
+            <setting label="" type="text" id="uk.chan5.session-token" default="" visible="false"/>
+
             <setting label="30250" type="text" id="uktvplay.login" default=""/>
             <setting label="30251" type="text" id="uktvplay.password" option="hidden" default=""/>
 


### PR DESCRIPTION
Added account login/logout
    - Does not store the username and password anywhere, only the token needed to make authenticated requests.
    - When the user logs in from settings, an actual login is performed and he immediately gets notified whether login was successful.

Added a folder in the main menu for user account related lists with:
    - 'My List' - a list of favourites saved at channel5. Each show, series and episode in any My5 listing now has a context menu item to add the show to MyList, or remove if it is already on the list.
    - 'We think you'll like' - recommendations from channel5 based on previously watched video's
    -  (more to follow)