### PR TITLE
[UK - MY5] report_play_time should not show msg on fail

### DIFF
--- a/resources/lib/channels/uk/channel4.py
+++ b/resources/lib/channels/uk/channel4.py
@@ -102,9 +102,6 @@ def get_access_token(plugin):
             token = login(plugin)
             if token:
                 return token
-        anonymous_token = get_anonymous_token(plugin)
-        if anonymous_token:
-            return anonymous_token
     except Exception:
         pass
 
@@ -155,25 +152,6 @@ def login(plugin):
 
     channel4_auth = res
     save_channel4_auth(channel4_auth)
-    return channel4_auth.get('accessToken', None)
-
-
-def get_anonymous_token(plugin):
-    data = {
-        "grant_type": "client_credentials",
-    }
-    r = requests.post(URL_AUTH_TOKEN, headers=AUTH_TOKEN_HEADERS, data=data)
-    try:
-        res = r.json()
-    except Exception:
-        Script.log('Failed to get anonymous token. ' + r.text)
-        plugin.notify('ERROR', 'Channel 4 : ' + plugin.localize(30711) + '. ' + r.text)
-
-    if res and "error" in res:
-        Script.log('Failed to get anonymous token. ' + res['errorMessage'])
-        plugin.notify('ERROR', 'Channel 4 : ' + plugin.localize(30711) + '. ' + res['errorMessage'])
-
-    channel4_auth = res
     return channel4_auth.get('accessToken', None)
 
 

--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -932,7 +932,7 @@ def sign_out_account(_):
 def report_play_time(evt, show_id):
     if evt.evt_type not in ('heartbeat', 'stopped'):
         return True
-    session_tkn = get_session_token()
+    session_tkn = get_session_token(False)
     if not session_tkn:
         return False
 


### PR DESCRIPTION
I don't use a login. When I stop a video, `report_play_time` shows a error dialog about missing login. 

@dimkroon 