### PR TITLE
[UK - MY5] Live: Make subtitles available by default.

### DIFF
--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -727,6 +727,7 @@ def get_live_url(plugin, item_id, **kwargs):
     LICFULL_URL, auth, aesKey = getdata(item_id, 'live_media')
     iv, data = ivdata(LICFULL_URL, auth)
     video_url, drm_url, sub_url = part2(iv, aesKey, data)
+    video_url = video_url.replace('subtitles=off', 'subtitles=on')
 
     return resolver_proxy.get_stream_with_quality(plugin, video_url=video_url, license_url=drm_url,
                                                   manifest_type='mpd', headers=lic_headers)


### PR DESCRIPTION
Currently, live subtitles are only available  when enabled in the account settings at channel5.com.

This makes live subs available by default, without a channel5 account. Users will still have to activate subtitles in Kodi's subtitle selection dialog while playing the stream.