### PR TITLE
[UK - WATCHFREEUK] Revert "Fix page legend has no items."

### DIFF
--- a/resources/lib/channels/uk/watchfreeuk.py
+++ b/resources/lib/channels/uk/watchfreeuk.py
@@ -216,7 +216,7 @@ def main_menu(plugin, **__):
         params={'url': BASE_URL + '/page/true-crime'}
     )
     yield Listitem.from_dict(
-        callback=list_home_page,
+        callback=list_page,
         label='Legend',
         params={'url': BASE_URL + '/page/legend'}
     )


### PR DESCRIPTION
This reverts commit 08df0b6b8b1bd142e5b502283b694329e1cdc1b1.

Page Legend is now back to what it was before; one long list of items.