### PR TITLE
[UK - MY5] Fix forbidden error on play

### DIFF
--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -119,11 +119,11 @@ def getdata(ui, media):
 
     matches = re.compile(r'([A-Za-z0-9+/]{22}==).*?([A-Za-z0-9+/]{22}==)').findall(sout)
     m = matches[0]
-    h = HMAC.new(base64.urlsafe_b64decode(str(m[0])), digestmod=SHA256)
+    h = HMAC.new(base64.urlsafe_b64decode(str(m[1])), digestmod=SHA256)
     h.update(hmac_update)
     auth = base64.urlsafe_b64encode(h.digest()).decode('utf-8')[:-1].replace("+", "-").replace("/", "_")
 
-    return CALL_URL, auth, m[1]
+    return CALL_URL, auth, m[0]
 
 
 def ivdata(lic_full, auth):


### PR DESCRIPTION
Again an issue with the HMAC key. It appears that HMAC and AES keys now come in a different order in the regex result.
To me, it looks like very little can be done to the regex to distinguish one from the other.