### PR TITLE
[UK - MY5] Swap and retry HMAC key with stored order.

### DIFF
--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -61,6 +61,7 @@ REQ_TIMEOUT = (3.5, 7)
 DFLT_CACHE_TIME = 600
 DFLT_SORT_METHODS = (xbmcplugin.SORT_METHOD_UNSORTED, xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE)
 DFLT_PAGE_SIZE = 50
+SETTING_ID_KEYS_REVERSED = 'uk.my5.key_order_reversed'
 
 GENERIC_HEADERS = {"User-Agent": web_utils.get_random_ua()}
 feeds_api_params = {
@@ -90,21 +91,12 @@ lic_headers = {
 my_list_ids = None
 
 
-def getdata(ui, media):
+def getdata():
     resp = urlquick.get(KEYURL, headers=GENERIC_HEADERS, timeout=REQ_TIMEOUT, max_age=0)
     content = resp.content.decode("utf-8", "ignore")
     ss = re.compile(r';}}}\)\(\'(......)\'\)};').search(content).group(1)
     m = re.compile(r'\(\){return "(.{3000,})";\}').search(content).group(1)
-
-    timeStamp = str(int(time.time()))
-    CALL_URL = LICC_URL % (media, ui, timeStamp)
-
-    try:
-        h = urllib.parse.unquote(m)
-        hmac_update = bytes(CALL_URL, encoding="utf-8")
-    except Exception:
-        h = urllib.unquote(m.encode('utf-8')).decode('utf-8', 'ignore')
-        hmac_update = str(CALL_URL)
+    h = urllib.parse.unquote(m)
 
     z = [ord(c) for c in h]
     y = 0
@@ -119,19 +111,40 @@ def getdata(ui, media):
 
     matches = re.compile(r'([A-Za-z0-9+/]{22}==).*?([A-Za-z0-9+/]{22}==)').findall(sout)
     m = matches[0]
-    h = HMAC.new(base64.urlsafe_b64decode(str(m[1])), digestmod=SHA256)
-    h.update(hmac_update)
-    auth = base64.urlsafe_b64encode(h.digest()).decode('utf-8')[:-1].replace("+", "-").replace("/", "_")
-
-    return CALL_URL, auth, m[0]
+    return m
 
 
-def ivdata(lic_full, auth):
-    params = {'auth': auth}
-    resp = urlquick.get(lic_full, headers=GENERIC_HEADERS, params=params,
-                        timeout=REQ_TIMEOUT, max_age=-1)
+def ivdata(item_id, media_type, keys):
+    timeStamp = str(int(time.time()))
+    lic_full = LICC_URL % (media_type, item_id, timeStamp)
+    hmac_update = bytes(lic_full, encoding="utf-8")
+    saved_swap = swap = Script.setting.get_boolean(SETTING_ID_KEYS_REVERSED)
+
+    # Calculate hmac and make the request. On 403 response, try one more time with swapped keys.
+    for tries in range(2):
+        if swap:
+            hmac_key, aes_key = keys
+        else:
+            aes_key, hmac_key = keys
+
+        h = HMAC.new(base64.urlsafe_b64decode(hmac_key), digestmod=SHA256)
+        h.update(hmac_update)
+        auth = base64.urlsafe_b64encode(h.digest()).decode('utf-8')[:-1].replace("+", "-").replace("/", "_")
+
+        params = {'auth': auth}
+        try:
+            resp = urlquick.get(lic_full, headers=GENERIC_HEADERS, params=params,
+                                timeout=REQ_TIMEOUT, max_age=-1)
+            break
+        except urlquick.HTTPError as err:
+            if err.response.status_code != 403 or tries > 0:
+                raise
+        swap = not swap
+
+    if saved_swap != swap:
+        Script.setting[SETTING_ID_KEYS_REVERSED] = str(swap).lower()
     root = json.loads(resp.text)
-    return root['iv'], root['data']
+    return root['iv'], root['data'], aes_key
 
 
 def mangle(result):
@@ -673,8 +686,8 @@ def get_video_url(plugin, fname, season_f_name, show_id, standalone, **kwargs):
         root = json.loads(resp.text)
         show_id = root['id']
 
-    LICFULL_URL, auth, aesKey = getdata(show_id, 'media')
-    iv, data = ivdata(LICFULL_URL, auth)
+    keys = getdata()
+    iv, data, aesKey = ivdata(show_id, 'media', keys)
     sd_video_url, drm_url, sub_url = part2(iv, aesKey, data)
 
     # Attempt to expose FHD resolutions
@@ -716,8 +729,8 @@ def get_video_url(plugin, fname, season_f_name, show_id, standalone, **kwargs):
 @Resolver.register
 def get_live_url(plugin, item_id, **kwargs):
 
-    LICFULL_URL, auth, aesKey = getdata(item_id, 'live_media')
-    iv, data = ivdata(LICFULL_URL, auth)
+    keys = getdata()
+    iv, data, aesKey = ivdata(item_id, 'live_media', keys)
     video_url, drm_url, sub_url = part2(iv, aesKey, data)
     video_url = video_url.replace('subtitles=off', 'subtitles=on')
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -91,6 +91,8 @@
             <!-- UK channels -->
             <setting label="30099" type="lsep" subsetting="true" visible="eq(1,true)"/>
                 <setting label="30183" type="labelenum" id="uk.channel4.programmes.sort.by" values="popular|az|recently-added" default="popular"/>
+                <!-- Hidden setting to store the order in which hmac and aes keys appear in data obtained from the web. -->
+                <setting label="" type="bool" id="uk.my5.key_order_reversed" default="false"  visible="false"/>
 
     </category>
     <!-- Quality and Content -->


### PR DESCRIPTION
Since the order in which hmac and aes keys appear in the list of keys varies, we save the last known order in a hidden setting. Just try the key based on this setting. If the server returns 403, swap keys, try again, and save the new setting.