### PR TITLE
[UK - WATCHFREEUK] Fix page legend has no items.

### DIFF
--- a/resources/lib/channels/uk/watchfreeuk.py
+++ b/resources/lib/channels/uk/watchfreeuk.py
@@ -216,7 +216,7 @@ def main_menu(plugin, **__):
         params={'url': BASE_URL + '/page/true-crime'}
     )
     yield Listitem.from_dict(
-        callback=list_page,
+        callback=list_home_page,
         label='Legend',
         params={'url': BASE_URL + '/page/legend'}
     )


### PR DESCRIPTION
The page has again changed into a structure with rails of collections, like the home page. Let's try it one more time, hoping it will remain stable now, but if it keeps changing back and forth, we must figure out some other solution.