### PR TITLE
Update to allow PR workflow to pass

### DIFF
--- a/resources/lib/channels/fr/cnews.py
+++ b/resources/lib/channels/fr/cnews.py
@@ -30,8 +30,7 @@ URL_VIDEOS_CNEWS = URL_ROOT_SITE + '/service/dm_loadmore/dm_emission_index_sujet
 
 GENERIC_HEADERS = {'User-Agent': web_utils.get_random_windows_ua()}
 
-URLLIB3_ADDON = xbmcaddon.Addon('script.module.urllib3')
-URLLIB3_VERSION = URLLIB3_ADDON.getAddonInfo('version')
+URLLIB3_VERSION = urlquick.requests.urllib3.__version__
 
 if URLLIB3_VERSION == "2.2.3":
     from urllib.request import urlopen, Request

--- a/resources/lib/channels/uk/greatplayer.py
+++ b/resources/lib/channels/uk/greatplayer.py
@@ -49,9 +49,11 @@ def get_anonymous_token():
     return None
 
 
-COOKIES = {
-    'one-token': get_anonymous_token().get('token'),
-}
+def cookies():
+    cks = getattr(cookies, '_cookies', None)
+    if cks is None:
+        cookies._cookies = cks = {'one-token': get_anonymous_token().get('token')}
+    return cks
 
 
 @Route.register
@@ -124,7 +126,7 @@ def main_menu(plugin, **kwargs):
 
 @Resolver.register
 def get_video(plugin, url, **kwargs):
-    json_video = json.loads(urlquick.get(url, cookies=COOKIES, max_age=-1).text)
+    json_video = json.loads(urlquick.get(url, cookies=cookies(), max_age=-1).text)
     video_streams = json_video.get('playbackInfo', {}).get('videoStreams', [])
     for video_stream in video_streams:
         if video_stream.get('label') == 'DASH-WIDEVINE':

--- a/resources/lib/channels/uk/tptvencore.py
+++ b/resources/lib/channels/uk/tptvencore.py
@@ -28,13 +28,13 @@ PRODUCTS_URL = API_CLIENT + '/v1/product'
 
 
 def get_token():
-    headers = {
+    tkn_headers = {
         'api-key': 'zq5pyPd0RTbNg3Fyj52PrkKL9c2Af38HHh4itgZTKDaCzjAyhd',
         'content-type': 'application/json',
         'tenant': TENANT
     }
 
-    token_response = requests.post(ANONYMOUS_TOKEN_URL, headers=headers, json={})
+    token_response = requests.post(ANONYMOUS_TOKEN_URL, headers=tkn_headers, json={})
 
     if token_response.status_code == 200:
         return token_response.json()
@@ -42,7 +42,11 @@ def get_token():
     return None
 
 
-HEADERS = {'session': get_token().get('id'), 'tenant': TENANT}
+def headers():
+    hdrs = getattr(headers, '_headers', None)
+    if hdrs is None:
+        headers._headers = hdrs = {'session': get_token().get('id'), 'tenant': TENANT}
+    return hdrs
 
 
 def get_products(product_ids):
@@ -51,14 +55,14 @@ def get_products(product_ids):
         'extend': 'label'
     }
 
-    product_json = json.loads(urlquick.get(PRODUCTS_URL, headers=HEADERS, params=params, max_age=-1).text)
+    product_json = json.loads(urlquick.get(PRODUCTS_URL, headers=headers(), params=params, max_age=-1).text)
     return product_json
 
 
 @Route.register(content_type='videos')
 def do_search(plugin, search_query):
     search_json = json.loads(
-        urlquick.get(PREDICTIVE_SEARCH_URL.format(search_query=quote(search_query)), headers=HEADERS, max_age=-1).text)
+        urlquick.get(PREDICTIVE_SEARCH_URL.format(search_query=quote(search_query)), headers=headers(), max_age=-1).text)
     if search_json:
         if 'data' in search_json:
             data = search_json.get('data', [])
@@ -103,7 +107,7 @@ def main_menu(plugin, **kwargs):
 
 @Resolver.register
 def get_video(plugin, product_id, **kwargs):
-    playout_json = json.loads(urlquick.get(VIDEO_URL.format(product_id=product_id), headers=HEADERS, max_age=-1).text)
+    playout_json = json.loads(urlquick.get(VIDEO_URL.format(product_id=product_id), headers=headers(), max_age=-1).text)
 
     brightcove = playout_json.get('brightcove', {})
     policy_key = brightcove.get('policyId')

--- a/resources/lib/channels/wo/tv5mondeplus.py
+++ b/resources/lib/channels/wo/tv5mondeplus.py
@@ -26,7 +26,13 @@ from resources.lib.menu_utils import item_post_treatment
 from resources.lib.web_utils import urlencode, get_random_ua
 
 GENERIC_HEADERS = get_random_ua()
-COUNTRY = web_utils.geoip()
+
+
+def country():
+    cntry = getattr(country, '_country', None)
+    if cntry is None:
+        country._country = cntry = web_utils.geoip()
+    return cntry
 
 
 def generate_fake_id():
@@ -79,14 +85,14 @@ def list_categories(plugin, item_id, **kwargs):
 
     params = {
         "onlyPublished": "true",
-        "allowedCountry": COUNTRY
+        "allowedCountry": country()
     }
 
     resp = urlquick.get(SANDWICH_API, params=params)
     json_parser = resp.json()
     category_reference_id = json_parser["components"]["menu"][0]["referenceId"]
 
-    resp2 = urlquick.get(COMPONENT_API % (category_reference_id, COUNTRY))
+    resp2 = urlquick.get(COMPONENT_API % (category_reference_id, country()))
     json_parser2 = resp2.json()
 
     item = Listitem.search(list_videos_search, item_id=item_id, page='0')
@@ -128,7 +134,7 @@ def list_videos_search(plugin, search_query, item_id, page, **kwargs):
         "locale": language,
         "schemes": ["keyword", "subcategory", "category", "origin"],
         "client": "json",
-        "allowedCountry": COUNTRY,
+        "allowedCountry": country(),
         "onlyPublished": "true"
     }
     if search_query is None or len(search_query) == 0:
@@ -148,7 +154,7 @@ def list_menu_sub_categories(plugin, item_id, menu_category_reference_id, **kwar
     - Les feux de l'amour
     - ...
     """
-    resp = urlquick.get(COMPONENT_API % (menu_category_reference_id, COUNTRY))
+    resp = urlquick.get(COMPONENT_API % (menu_category_reference_id, country()))
     json_parser = resp.json()
 
     for menu_sub_category_data in json_parser["components"]["pageBody"]:
@@ -176,7 +182,7 @@ def list_programs(plugin, item_id, program_reference_id, **kwargs):
     - ...
     """
     language = Script.setting['tv5mondeplus.language']
-    resp = urlquick.get(COMPONENT_API % (program_reference_id, COUNTRY))
+    resp = urlquick.get(COMPONENT_API % (program_reference_id, country()))
     json_parser = resp.json()
 
     new_url = BASE_URL_API + json_parser["contentUrl"]["url"]


### PR DESCRIPTION
Some changes to various channels to better support automated tests. This should finally allow the pr workflow to pass successfully.

Mostly concerns avoiding web requests on module import. 
Web requests may fail for many reasons, like geo blocks, or just API changes, which can cause tests to fail for reasons not related to the actual test. Doing HTTP requests on module import is not very elegant anyway, IMO.

@CasperMcFadden95 : just to notify that uk-tptvencore currently fails (and it did so on import), just in case you're not already aware, seeing you're the author of this channel.