### PR TITLE
[UK - MY5] Fixed regex causing all videos to fail with "padding error"

### DIFF
--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -106,8 +106,8 @@ def getdata():
             sout = sout + chr(k)
         y = y + 1
 
-    matches = re.compile(r'([A-Za-z0-9+/]{22}==).*?([A-Za-z0-9+/]{22}==)').findall(sout)
-    return matches[0]
+    matches = re.findall(r'(?:\W\W|^)([A-Za-z0-9+/]{22}==)(?:\W\W|$)', sout)
+    return matches
 
 
 def ivdata(item_id, media_type, keys):


### PR DESCRIPTION
Again a key issue. The regex found 2 false positives. Only the first 2 were used, which happened to be the hmac and a false positive. The latter was the cause of incorrect AES decryption and the subsequent padding error.

From the data I logged since the first key issues, it looks like the constants within the data string we search are always delimited by a sequence 2 non-word characters, but the characters change as often as the keys.

The regex now looks for key sequences within these delimiters, allowing for the key to be at the start or the end of the data.
Used re.findall() to allow re to cache the compiled regex.

Fixes #1794 