### PR TITLE
[UK] Fix playable items do not always show the correct progress/play state

### DIFF
--- a/resources/lib/channels/uk/channel4.py
+++ b/resources/lib/channels/uk/channel4.py
@@ -667,6 +667,7 @@ def parse_api_item_episode(episode_item, parent_list=None):
         item.context.script(remove_from_history, 'Remove from history', programme_id=programme_id)
     add_my_list_context_menu(item, brand_ws_title)
     item_post_treatment(item)
+    item.params['_title_'] = ''
     return item
 
 
@@ -818,6 +819,7 @@ def list_seasons(plugin, url, **kwargs):
                         item.info['genre'] = genres
                         add_my_list_context_menu(item, brand_name)
                         item_post_treatment(item)
+                        item.params['_title_'] = ''
                         yield item
             else:
                 series = datas['series']
@@ -876,6 +878,7 @@ def get_episodes_list(plugin, series, series_number, datas, **kwargs):
             item.info['genre'] = genres
             add_my_list_context_menu(item, brand_name)
             item_post_treatment(item)
+            item.params['_title_'] = ''
             yield item
 
 

--- a/resources/lib/channels/uk/my5.py
+++ b/resources/lib/channels/uk/my5.py
@@ -613,6 +613,8 @@ def parse_watchable(watchable, from_episode_list=False):
                       standalone="no")
     mylist_ctx_mnu(item, watchable['sh_id'], show_title)
     item_post_treatment(item)
+    # Ensure callback urls are the same for identical items, regardless of the title text.
+    item.params['_title_'] = ''
     return item
 
 


### PR DESCRIPTION
Kodi identifies playable items by their callback url and uses this as key to track wheter an item is partialy or fully played. By default, Codequick adds an item's title as querytring parameter to the callback URL, while it's not used by codequick, nor to play the item.

However, the title of a playable can vary for many reasons. We sometimes choose to display an item in a different format, depending on the type of list it appears in, but the webcaster can also sometimes change the title while the actual content remains the same. As a result, the same video can appear as 'in progress' in one list and 'not played', or 'fully played' in another. 

This PR clears the default parameter that Codequick has added to ensure that identical videos have the same callback url, regardless of the title being displayed. If a video is played from one list, it will now appear as 'played' in any other list that includes this item.

It's now only applied to some UK channels, but it might be worth doing it at project level. e.g. in menu_utils,item_post_treatment()